### PR TITLE
Accept bignumber and orderedlist as display types

### DIFF
--- a/resource_metric_condition.go
+++ b/resource_metric_condition.go
@@ -142,7 +142,7 @@ func getQuerySchema() map[string]*schema.Schema {
 		"display": {
 			Type:         schema.TypeString,
 			Optional:     true,
-			ValidateFunc: validation.StringInSlice([]string{"line", "area", "bar", "bignumber", "orderedlist"}, false),
+			ValidateFunc: validation.StringInSlice([]string{"line", "area", "bar", "big_number", "ordered_list"}, false),
 		},
 		"query_name": {
 			Type:     schema.TypeString,


### PR DESCRIPTION
R: @lightstep/team-dashboards 

Add bignumber and orderedlist so it aligns with this: https://github.com/lightstep/lightstep/blob/5663ff45c84b34c21fe6276fd7c8cfb1284e9f50/go/src/github.com/lightstep/crouton/service/api/wc/applicationmetrics/query.go#L113-L115