### PR TITLE
Revert "Accept bignumber and orderedlist as display types"

### DIFF
--- a/resource_metric_condition.go
+++ b/resource_metric_condition.go
@@ -142,7 +142,7 @@ func getQuerySchema() map[string]*schema.Schema {
 		"display": {
 			Type:         schema.TypeString,
 			Optional:     true,
-			ValidateFunc: validation.StringInSlice([]string{"line", "area", "bar", "big_number", "ordered_list"}, false),
+			ValidateFunc: validation.StringInSlice([]string{"line", "area", "bar"}, false),
 		},
 		"query_name": {
 			Type:     schema.TypeString,


### PR DESCRIPTION
Reverts lightstep/terraform-provider-lightstep#54

When I merged the PR, the Codefresh pipeline automatically built and published it with the same release tag as before: 1.45. 

https://g.codefresh.io/build/615e181963646d17fff8f7fe?step=tag_repo&tab=output&logs=terminal

I'm not sure why this happened (do I need to manually create a release here? https://github.com/lightstep/terraform-provider-lightstep/releases/new)

This is now producing errors when someone runs make install-tools and tries to lightstep terraform:

```
╷
│ Error: Failed to install provider from shared cache
│
│ Error while importing terraform.lightstep.com/lightstep-org/lightstep v1.45.0 from the shared cache
│ directory: the provider cache at .terraform/providers has a copy of
│ terraform.lightstep.com/lightstep-org/lightstep 1.45.0 that doesn't match any of the checksums
│ recorded in the dependency lock file.
```

I don't understand what's happening here, so I'm reverting the change until I figure out what are the right steps. 