### PR TITLE
fix: Gracefully error on GetStream non-API errors

### DIFF
--- a/lightstep/resource_stream.go
+++ b/lightstep/resource_stream.go
@@ -3,10 +3,11 @@ package lightstep
 import (
 	"context"
 	"fmt"
-	"github.com/lightstep/terraform-provider-lightstep/client"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/lightstep/terraform-provider-lightstep/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -94,12 +95,12 @@ func resourceStreamRead(ctx context.Context, d *schema.ResourceData, m interface
 	c := m.(*client.Client)
 	s, err := c.GetStream(ctx, d.Get("project_name").(string), d.Id())
 	if err != nil {
-		apiErr := err.(client.APIResponseCarrier)
-		if apiErr.GetHTTPResponse().StatusCode == http.StatusNotFound {
+		apiErr, isApiErr := err.(client.APIResponseCarrier)
+		if isApiErr && apiErr.GetHTTPResponse().StatusCode == http.StatusNotFound {
 			d.SetId("")
 			return diags
 		}
-		return diag.FromErr(fmt.Errorf("Failed to get stream: %v\n", apiErr))
+		return diag.FromErr(fmt.Errorf("Failed to get stream: %v\n", err))
 	}
 
 	if err := setResourceDataFromStream(d, *s); err != nil {


### PR DESCRIPTION
I observed this error while applying:

    │ The plugin encountered an error, and failed to respond to the
    │ plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details.
    ╵

    Stack trace from the terraform-provider-lightstep_v1.51.2 plugin:

    panic: interface conversion: *errors.errorString is not client.APIResponseCarrier: missing method GetHTTPResponse

    goroutine 116 [running]:
    github.com/lightstep/terraform-provider-lightstep/lightstep.resourceStreamRead(0xde00a8, 0xc0002fa1e0, 0xc0002eec00, 0xcce280, 0xc0004b5aa0, 0xc0001d8ec0, 0x33, 0xc0002f2100)
            github.com/lightstep/terraform-provider-lightstep/lightstep/resource_stream.go:97 +0x165
    github.com/lightstep/terraform-provider-lightstep/lightstep.resourceStreamCreate.func1(0x2)
            github.com/lightstep/terraform-provider-lightstep/lightstep/resource_stream.go:75 +0x6bf
    github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource.RetryContext.func1(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
            github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.0/helper/resource/wait.go:27 +0x5b
    github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource.(*StateChangeConf).WaitForStateContext.func1(0xc0002fa2a0, 0xc0002189a0, 0xc000163440, 0xc0002c7200, 0xc00058f9d0, 0xc00058f9b8)
            github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.0/helper/resource/state.go:110 +0x2e9
    created by github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource.(*StateChangeConf).WaitForStateContext
            github.com/hashicorp/terraform-plugin-sdk/v2@v2.10.0/helper/resource/state.go:83 +0x1c6

    Error: The terraform-provider-lightstep_v1.51.2 plugin crashed!

It seems we can fix it by just handling type assertion failures for
`APIResponseCarrier`.