### PR TITLE
LS-27435: Prevent exception when response is nil

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -96,8 +96,12 @@ func NewClientWithUserAgent(apiKey string, orgName string, env string, userAgent
 
 // checkHTTPRetry inspects HTTP errors from the Lightstep API for known transient errors
 func checkHTTPRetry(_ context.Context, resp *http.Response, err error) (bool, error) {
+	if resp == nil {
+		// If response is nil we can't make retry choices.
+		return false, err
+	}
 	if resp.StatusCode == http.StatusInternalServerError || resp.StatusCode == http.StatusServiceUnavailable {
-		return true, nil
+		return true, err
 	}
 	return false, nil
 }


### PR DESCRIPTION
* Fixes fatal exception when response object is nil in http client retry logic. (cc @gdvalle)

```
Stack trace from the terraform-provider-lightstep_v1.51.3 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xb236e5]

goroutine 114 [running]:
github.com/lightstep/terraform-provider-lightstep/client.checkHTTPRetry(0xde00c8, 0xc000115ec0, 0x0, 0xdd1740, 0xc0008e8990, 0x0, 0x0, 0x1)
```

cc @bcronin @adil-sultan 