### PR TITLE
metric dashboards: Remove y-axis

### DIFF
--- a/client/metric_dashboards.go
+++ b/client/metric_dashboards.go
@@ -23,13 +23,7 @@ type MetricChart struct {
 	ID            string                      `json:"id"`
 	Title         string                      `json:"title"`
 	ChartType     string                      `json:"chart-type"`
-	YAxis         *YAxis                      `json:"y-axis"`
 	MetricQueries []MetricQueryWithAttributes `json:"metric-queries"`
-}
-
-type YAxis struct {
-	Min float64 `json:"min"`
-	Max float64 `json:"max"`
 }
 
 type MetricGroupBy struct {

--- a/lightstep/resource_metric_dashboard.go
+++ b/lightstep/resource_metric_dashboard.go
@@ -64,6 +64,25 @@ func getChartSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
+		// The y_axis is included here for backwards compatibility, but it's not used anywhere
+		// because it has been removed from Lightstep's public API.
+		"y_axis": {
+			Type:     schema.TypeList,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"min": {
+						Type:     schema.TypeFloat,
+						Required: true,
+					},
+					"max": {
+						Type:     schema.TypeFloat,
+						Required: true,
+					},
+				},
+			},
+			Optional: true,
+		},
 		"query": {
 			Type:     schema.TypeList,
 			Required: true,


### PR DESCRIPTION
The y-axis was optional and is being removed from Lightstep's
public API, so remove support for it here.