### PR TITLE
Fix for diff issue related to chart rank, increase API timeout

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -20,7 +20,7 @@ import (
 const (
 	DefaultRateLimitPerSecond = 2
 	DefaultRetryMax           = 3
-	DefaultTimeoutSeconds     = 30
+	DefaultTimeoutSeconds     = 60
 	DefaultUserAgent          = "terraform-provider-lightstep"
 )
 

--- a/lightstep/resource_metric_dashboard.go
+++ b/lightstep/resource_metric_dashboard.go
@@ -35,7 +35,7 @@ func resourceMetricDashboard() *schema.Resource {
 				Computed: true,
 			},
 			"chart": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: getChartSchema(),
@@ -137,7 +137,8 @@ func resourceMetricDashboardRead(ctx context.Context, d *schema.ResourceData, m 
 }
 
 func getMetricDashboardAttributesFromResource(d *schema.ResourceData) (*client.MetricDashboardAttributes, error) {
-	charts, err := buildCharts(d.Get("chart").([]interface{}))
+	chartSet := d.Get("chart").(*schema.Set)
+	charts, err := buildCharts(chartSet.List())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* Updates schema so diffs do not get created when chart rank does not match the position of the JSON array sent to the API:

```
# results in a diff every time an apply is run
chart {
  rank = 2
}
chart {
  rank = 1
}
```

* Increases API timeout to 60s