### PR TITLE
Allow "avg" as valid timeseries_operator.

### DIFF
--- a/lightstep/resource_metric_condition.go
+++ b/lightstep/resource_metric_condition.go
@@ -212,7 +212,7 @@ func getQuerySchema(includeSpansQuery bool) map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			Optional:     true,
 			Computed:     true,
-			ValidateFunc: validation.StringInSlice([]string{"rate", "delta", "mean", "last"}, false),
+			ValidateFunc: validation.StringInSlice([]string{"rate", "delta", "mean", "avg", "last"}, false),
 		},
 		"filters": {
 			Type:        schema.TypeList,


### PR DESCRIPTION
Allow "avg" as valid timeseries_operator.

![image](https://user-images.githubusercontent.com/509887/169559654-534aeac2-86e1-489c-9024-c1f9d42c04d0.png)
