### PR TITLE
Fix Go lint warnings

### DIFF
--- a/lightstep/data_source_stream.go
+++ b/lightstep/data_source_stream.go
@@ -44,9 +44,9 @@ func dataSourceLightstepStreamRead(ctx context.Context, d *schema.ResourceData, 
 		apiErr := err.(client.APIResponseCarrier)
 		if apiErr.GetHTTPResponse().StatusCode == http.StatusNotFound {
 			d.SetId("")
-			return diag.FromErr(fmt.Errorf("Stream not found: %v\n", apiErr))
+			return diag.FromErr(fmt.Errorf("stream not found: %v", apiErr))
 		}
-		return diag.FromErr(fmt.Errorf("Failed to get stream: %v\n", apiErr))
+		return diag.FromErr(fmt.Errorf("failed to get stream: %v", apiErr))
 	}
 	d.SetId(s.ID)
 	if err := d.Set("stream_name", s.Attributes.Name); err != nil {

--- a/lightstep/resource_alerting_rule.go
+++ b/lightstep/resource_alerting_rule.go
@@ -60,12 +60,12 @@ func resourceAlertingRuleCreate(ctx context.Context, d *schema.ResourceData, m i
 		d.Get("destination_id").(string),
 		d.Get("condition_id").(string))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to create alerting rule: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to create alerting rule: %v", err))
 	}
 
 	d.SetId(rule.ID)
 	if err := setResourceDataFromAlertingRule(d, rule); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to set alerting rule response from API to terraform state: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to set alerting rule response from API to terraform state: %v", err))
 	}
 
 	return diags
@@ -82,11 +82,11 @@ func resourceAlertingRuleRead(ctx context.Context, d *schema.ResourceData, m int
 			d.SetId("")
 			return diags
 		}
-		return diag.FromErr(fmt.Errorf("Failed to get alerting rule: %v\n", apiErr))
+		return diag.FromErr(fmt.Errorf("failed to get alerting rule: %v", apiErr))
 	}
 
 	if err := setResourceDataFromAlertingRule(d, *rule); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to set alerting rule response from API to terraform state: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to set alerting rule response from API to terraform state: %v", err))
 	}
 
 	return diags
@@ -97,7 +97,7 @@ func resourceAlertingRuleDelete(ctx context.Context, d *schema.ResourceData, m i
 
 	client := m.(*client.Client)
 	if err := client.DeleteAlertingRule(ctx, d.Get("project_name").(string), d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to delete alerting rule: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to delete alerting rule: %v", err))
 	}
 
 	return diags
@@ -108,7 +108,7 @@ func resourceAlertingRuleImport(ctx context.Context, d *schema.ResourceData, m i
 
 	ids := strings.Split(d.Id(), ".")
 	if len(ids) != 2 {
-		return []*schema.ResourceData{}, fmt.Errorf("Error importing lightstep_alerting_rule. Expecting an  ID formed as '<lightstep_project>.<lightstep_lightstep_alerting_rule_ID>'")
+		return []*schema.ResourceData{}, fmt.Errorf("error importing lightstep_alerting_rule. Expecting an  ID formed as '<lightstep_project>.<lightstep_lightstep_alerting_rule_ID>'")
 	}
 
 	project, id := ids[0], ids[1]

--- a/lightstep/resource_alerting_rule_test.go
+++ b/lightstep/resource_alerting_rule_test.go
@@ -184,7 +184,7 @@ func testAccCheckAlertingRuleExists(resourceName string, rule *client.StreamAler
 		}
 
 		if tfRule.Primary.ID == "" {
-			return fmt.Errorf("iD is not set")
+			return fmt.Errorf("id is not set")
 		}
 
 		c := testAccProvider.Meta().(*client.Client)

--- a/lightstep/resource_alerting_rule_test.go
+++ b/lightstep/resource_alerting_rule_test.go
@@ -3,8 +3,9 @@ package lightstep
 import (
 	"context"
 	"fmt"
-	"github.com/lightstep/terraform-provider-lightstep/client"
 	"regexp"
+
+	"github.com/lightstep/terraform-provider-lightstep/client"
 
 	"testing"
 
@@ -179,11 +180,11 @@ func testAccCheckAlertingRuleExists(resourceName string, rule *client.StreamAler
 	return func(s *terraform.State) error {
 		tfRule, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
 		if tfRule.Primary.ID == "" {
-			return fmt.Errorf("ID is not set")
+			return fmt.Errorf("iD is not set")
 		}
 
 		c := testAccProvider.Meta().(*client.Client)
@@ -209,7 +210,7 @@ func testAccAlertingRuleDestroy(s *terraform.State) error {
 		s, err := conn.GetAlertingRule(context.Background(), test_project, resource.Primary.ID)
 		if err == nil {
 			if s.ID == resource.Primary.ID {
-				return fmt.Errorf("Alerting Rule with ID (%v) still exists.", resource.Primary.ID)
+				return fmt.Errorf("alerting Rule with ID (%v) still exists.", resource.Primary.ID)
 			}
 		}
 	}

--- a/lightstep/resource_dashboard_test.go
+++ b/lightstep/resource_dashboard_test.go
@@ -1,15 +1,12 @@
 package lightstep
 
 import (
-	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/lightstep/terraform-provider-lightstep/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDashboard(t *testing.T) {
@@ -154,43 +151,4 @@ resource "lightstep_dashboard" "test" {
 			},
 		},
 	})
-}
-
-func testGetDashboardDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*client.Client)
-	for _, r := range s.RootModule().Resources {
-		if r.Type != "metric_alert" {
-			continue
-		}
-
-		s, err := conn.GetUnifiedDashboard(context.Background(), test_project, r.Primary.ID)
-		if err == nil {
-			if s.ID == r.Primary.ID {
-				return fmt.Errorf("Dashboard with ID (%v) still exists.", r.Primary.ID)
-			}
-		}
-	}
-	return nil
-}
-
-func testAccCheckDashboardExists(resourceName string, dashboard *client.UnifiedDashboard) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		tfDashboard, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		if tfDashboard.Primary.ID == "" {
-			return fmt.Errorf("ID is not set")
-		}
-
-		c := testAccProvider.Meta().(*client.Client)
-		dash, err := c.GetUnifiedDashboard(context.Background(), test_project, tfDashboard.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		dashboard = dash
-		return nil
-	}
 }

--- a/lightstep/resource_destination.go
+++ b/lightstep/resource_destination.go
@@ -23,7 +23,7 @@ func resourceDestinationRead(ctx context.Context, d *schema.ResourceData, m inte
 			d.SetId("")
 			return diags
 		}
-		return diag.FromErr(fmt.Errorf("Failed to get destination: %v\n", apiErr))
+		return diag.FromErr(fmt.Errorf("failed to get destination: %v", apiErr))
 	}
 	d.SetId(dest.ID)
 	return diags
@@ -34,7 +34,7 @@ func resourceDestinationDelete(ctx context.Context, d *schema.ResourceData, m in
 
 	client := m.(*client.Client)
 	if err := client.DeleteDestination(ctx, d.Get("project_name").(string), d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to delete destination: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to delete destination: %v", err))
 	}
 
 	return diags
@@ -43,7 +43,7 @@ func resourceDestinationDelete(ctx context.Context, d *schema.ResourceData, m in
 func splitID(id string) ([]string, error) {
 	ids := strings.Split(id, ".")
 	if len(ids) != 2 {
-		return nil, fmt.Errorf("Error importing lightstep_pagerduty_destination. Expecting an ID formed as '<lightstep_project>.<lightstep_destination_ID>'")
+		return nil, fmt.Errorf("error importing lightstep_pagerduty_destination. Expecting an ID formed as '<lightstep_project>.<lightstep_destination_ID>'")
 	}
 	return ids, nil
 }

--- a/lightstep/resource_metric_condition.go
+++ b/lightstep/resource_metric_condition.go
@@ -311,7 +311,7 @@ func resourceMetricConditionCreate(ctx context.Context, d *schema.ResourceData, 
 	c := m.(*client.Client)
 	attributes, err := getMetricConditionAttributesFromResource(d)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to get metric condition attributes from resource : %v", err))
+		return diag.FromErr(fmt.Errorf("failed to get metric condition attributes from resource : %v", err))
 	}
 
 	condition := client.MetricCondition{
@@ -321,7 +321,7 @@ func resourceMetricConditionCreate(ctx context.Context, d *schema.ResourceData, 
 
 	created, err := c.CreateMetricCondition(ctx, d.Get("project_name").(string), condition)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to create metric condition: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to create metric condition: %v", err))
 	}
 
 	d.SetId(created.ID)
@@ -339,11 +339,11 @@ func resourceMetricConditionRead(ctx context.Context, d *schema.ResourceData, m 
 			d.SetId("")
 			return diags
 		}
-		return diag.FromErr(fmt.Errorf("Failed to get metric condition: %v\n", apiErr))
+		return diag.FromErr(fmt.Errorf("failed to get metric condition: %v", apiErr))
 	}
 
 	if err := setResourceDataFromMetricCondition(d.Get("project_name").(string), *cond, d); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to set metric condition from API response to terraform state: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to set metric condition from API response to terraform state: %v", err))
 	}
 
 	return diags
@@ -353,11 +353,11 @@ func resourceMetricConditionUpdate(ctx context.Context, d *schema.ResourceData, 
 	c := m.(*client.Client)
 	attrs, err := getMetricConditionAttributesFromResource(d)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to get metric condition attributes from resource : %v", err))
+		return diag.FromErr(fmt.Errorf("failed to get metric condition attributes from resource : %v", err))
 	}
 
 	if _, err := c.UpdateMetricCondition(ctx, d.Get("project_name").(string), d.Id(), *attrs); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to update metric condition: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to update metric condition: %v", err))
 	}
 
 	return resourceMetricConditionRead(ctx, d, m)
@@ -368,7 +368,7 @@ func resourceMetricConditionDelete(ctx context.Context, d *schema.ResourceData, 
 
 	c := m.(*client.Client)
 	if err := c.DeleteMetricCondition(ctx, d.Get("project_name").(string), d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to detele metrics condition: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to detele metrics condition: %v", err))
 	}
 
 	// d.SetId("") is automatically called assuming delete returns no errors, but
@@ -382,18 +382,18 @@ func resourceMetricConditionImport(ctx context.Context, d *schema.ResourceData, 
 
 	ids := strings.Split(d.Id(), ".")
 	if len(ids) != 2 {
-		return []*schema.ResourceData{}, fmt.Errorf("Error importing lightstep_metric_condition. Expecting an  ID formed as '<lightstep_project>.<lightstep_metric_condition_ID>'")
+		return []*schema.ResourceData{}, fmt.Errorf("error importing lightstep_metric_condition. Expecting an  ID formed as '<lightstep_project>.<lightstep_metric_condition_ID>'")
 	}
 
 	project, id := ids[0], ids[1]
 	c, err := clnt.GetMetricCondition(ctx, project, id)
 	if err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("Failed to get metric condition. err: %v", err)
+		return []*schema.ResourceData{}, fmt.Errorf("failed to get metric condition. err: %v", err)
 	}
 
 	d.SetId(id)
 	if err := setResourceDataFromMetricCondition(project, *c, d); err != nil {
-		return nil, fmt.Errorf("Failed to set metric condition from API response to terraform state: %v", err)
+		return nil, fmt.Errorf("failed to set metric condition from API response to terraform state: %v", err)
 	}
 
 	return []*schema.ResourceData{d}, nil
@@ -853,19 +853,19 @@ func validateGroupBy(groupBy interface{}, queryType string) error {
 
 func setResourceDataFromMetricCondition(project string, c client.MetricCondition, d *schema.ResourceData) error {
 	if err := d.Set("project_name", project); err != nil {
-		return fmt.Errorf("Unable to set project_name resource field: %v", err)
+		return fmt.Errorf("unable to set project_name resource field: %v", err)
 	}
 
 	if err := d.Set("name", c.Attributes.Name); err != nil {
-		return fmt.Errorf("Unable to set name resource field: %v", err)
+		return fmt.Errorf("unable to set name resource field: %v", err)
 	}
 
 	if err := d.Set("description", c.Attributes.Description); err != nil {
-		return fmt.Errorf("Unable to set description resource field: %v", err)
+		return fmt.Errorf("unable to set description resource field: %v", err)
 	}
 
 	if err := d.Set("type", "metric_alert"); err != nil {
-		return fmt.Errorf("Unable to set type resource field: %v", err)
+		return fmt.Errorf("unable to set type resource field: %v", err)
 	}
 
 	thresholdEntries := map[string]interface{}{}
@@ -888,12 +888,12 @@ func setResourceDataFromMetricCondition(project string, c client.MetricCondition
 			},
 		},
 	}); err != nil {
-		return fmt.Errorf("Unable to set expression resource field: %v", err)
+		return fmt.Errorf("unable to set expression resource field: %v", err)
 	}
 
 	queries := getQueriesFromMetricDashboardResourceData(c.Attributes.Queries)
 	if err := d.Set("metric_query", queries); err != nil {
-		return fmt.Errorf("Unable to set metric_proxy resource field: %v", err)
+		return fmt.Errorf("unable to set metric_proxy resource field: %v", err)
 	}
 
 	var alertingRules []interface{}
@@ -910,7 +910,7 @@ func setResourceDataFromMetricCondition(project string, c client.MetricCondition
 	}
 
 	if err := d.Set("alerting_rule", alertingRules); err != nil {
-		return fmt.Errorf("Unable to set alerting_rule resource field: %v", err)
+		return fmt.Errorf("unable to set alerting_rule resource field: %v", err)
 	}
 
 	return nil

--- a/lightstep/resource_metric_condition_test.go
+++ b/lightstep/resource_metric_condition_test.go
@@ -836,7 +836,7 @@ func testAccCheckMetricConditionExists(resourceName string, condition *client.Me
 		}
 
 		if tfCondition.Primary.ID == "" {
-			return fmt.Errorf("iD is not set")
+			return fmt.Errorf("id is not set")
 		}
 
 		providerClient := testAccProvider.Meta().(*client.Client)

--- a/lightstep/resource_metric_condition_test.go
+++ b/lightstep/resource_metric_condition_test.go
@@ -832,11 +832,11 @@ func testAccCheckMetricConditionExists(resourceName string, condition *client.Me
 	return func(s *terraform.State) error {
 		tfCondition, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
 		if tfCondition.Primary.ID == "" {
-			return fmt.Errorf("ID is not set")
+			return fmt.Errorf("iD is not set")
 		}
 
 		providerClient := testAccProvider.Meta().(*client.Client)
@@ -860,7 +860,7 @@ func testAccMetricConditionDestroy(s *terraform.State) error {
 		s, err := conn.GetMetricCondition(context.Background(), test_project, res.Primary.ID)
 		if err == nil {
 			if s.ID == res.Primary.ID {
-				return fmt.Errorf("Metric condition with ID (%v) still exists.", res.Primary.ID)
+				return fmt.Errorf("metric condition with ID (%v) still exists.", res.Primary.ID)
 			}
 		}
 	}

--- a/lightstep/resource_metric_dashboard.go
+++ b/lightstep/resource_metric_dashboard.go
@@ -126,7 +126,7 @@ func (p *resourceUnifiedDashboardImp) resourceUnifiedDashboardCreate(ctx context
 	c := m.(*client.Client)
 	attrs, err := getUnifiedDashboardAttributesFromResource(d)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to get dashboard attributes: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to get dashboard attributes: %v", err))
 	}
 
 	dashboard := client.UnifiedDashboard{
@@ -136,7 +136,7 @@ func (p *resourceUnifiedDashboardImp) resourceUnifiedDashboardCreate(ctx context
 
 	created, err := c.CreateUnifiedDashboard(ctx, d.Get("project_name").(string), dashboard)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to create dashboard: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to create dashboard: %v", err))
 	}
 
 	d.SetId(created.ID)
@@ -155,11 +155,11 @@ func (p *resourceUnifiedDashboardImp) resourceUnifiedDashboardRead(ctx context.C
 			d.SetId("")
 			return diags
 		}
-		return diag.FromErr(fmt.Errorf("Failed to get dashboard: %v\n", apiErr))
+		return diag.FromErr(fmt.Errorf("failed to get dashboard: %v", apiErr))
 	}
 
 	if err := p.setResourceDataFromUnifiedDashboard(d.Get("project_name").(string), *dashboard, d); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to set dashboard from API response to terraform state: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to set dashboard from API response to terraform state: %v", err))
 	}
 
 	return diags
@@ -225,12 +225,12 @@ func buildYAxis(yAxisIn []interface{}) (*client.YAxis, error) {
 
 	max, ok := y["max"].(float64)
 	if !ok {
-		return nil, fmt.Errorf("Missing required attribute 'max' for y_axis")
+		return nil, fmt.Errorf("missing required attribute 'max' for y_axis")
 	}
 
 	min, ok := y["min"].(float64)
 	if !ok {
-		return nil, fmt.Errorf("Missing required attribute 'min' for y_axis")
+		return nil, fmt.Errorf("missing required attribute 'min' for y_axis")
 	}
 
 	yAxis := &client.YAxis{
@@ -243,15 +243,15 @@ func buildYAxis(yAxisIn []interface{}) (*client.YAxis, error) {
 
 func (p *resourceUnifiedDashboardImp) setResourceDataFromUnifiedDashboard(project string, dash client.UnifiedDashboard, d *schema.ResourceData) error {
 	if err := d.Set("project_name", project); err != nil {
-		return fmt.Errorf("Unable to set project_name resource field: %v", err)
+		return fmt.Errorf("unable to set project_name resource field: %v", err)
 	}
 
 	if err := d.Set("dashboard_name", dash.Attributes.Name); err != nil {
-		return fmt.Errorf("Unable to set dashboard_name resource field: %v", err)
+		return fmt.Errorf("unable to set dashboard_name resource field: %v", err)
 	}
 
 	if err := d.Set("type", dash.Type); err != nil {
-		return fmt.Errorf("Unable to set type resource field: %v", err)
+		return fmt.Errorf("unable to set type resource field: %v", err)
 	}
 
 	var charts []interface{}
@@ -280,7 +280,7 @@ func (p *resourceUnifiedDashboardImp) setResourceDataFromUnifiedDashboard(projec
 	}
 
 	if err := d.Set("chart", charts); err != nil {
-		return fmt.Errorf("Unable to set chart resource field: %v", err)
+		return fmt.Errorf("unable to set chart resource field: %v", err)
 	}
 
 	return nil
@@ -290,11 +290,11 @@ func (p *resourceUnifiedDashboardImp) resourceUnifiedDashboardUpdate(ctx context
 	c := m.(*client.Client)
 	attrs, err := getUnifiedDashboardAttributesFromResource(d)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to get dashboard attributes from resource : %v", err))
+		return diag.FromErr(fmt.Errorf("failed to get dashboard attributes from resource : %v", err))
 	}
 
 	if _, err := c.UpdateUnifiedDashboard(ctx, d.Get("project_name").(string), d.Id(), *attrs); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to update dashboard: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to update dashboard: %v", err))
 	}
 
 	return p.resourceUnifiedDashboardRead(ctx, d, m)

--- a/lightstep/resource_metric_dashboard_test.go
+++ b/lightstep/resource_metric_dashboard_test.go
@@ -259,7 +259,7 @@ func testGetMetricDashboardDestroy(s *terraform.State) error {
 		s, err := conn.GetUnifiedDashboard(context.Background(), test_project, r.Primary.ID)
 		if err == nil {
 			if s.ID == r.Primary.ID {
-				return fmt.Errorf("Metric dashboard with ID (%v) still exists.", r.Primary.ID)
+				return fmt.Errorf("metric dashboard with ID (%v) still exists.", r.Primary.ID)
 			}
 		}
 	}
@@ -270,11 +270,11 @@ func testAccCheckMetricDashboardExists(resourceName string, dashboard *client.Un
 	return func(s *terraform.State) error {
 		tfDashboard, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
 		if tfDashboard.Primary.ID == "" {
-			return fmt.Errorf("ID is not set")
+			return fmt.Errorf("iD is not set")
 		}
 
 		c := testAccProvider.Meta().(*client.Client)

--- a/lightstep/resource_metric_dashboard_test.go
+++ b/lightstep/resource_metric_dashboard_test.go
@@ -274,7 +274,7 @@ func testAccCheckMetricDashboardExists(resourceName string, dashboard *client.Un
 		}
 
 		if tfDashboard.Primary.ID == "" {
-			return fmt.Errorf("iD is not set")
+			return fmt.Errorf("id is not set")
 		}
 
 		c := testAccProvider.Meta().(*client.Client)

--- a/lightstep/resource_pagerduty_destination.go
+++ b/lightstep/resource_pagerduty_destination.go
@@ -53,7 +53,7 @@ func resourcePagerdutyDestinationCreate(ctx context.Context, d *schema.ResourceD
 			},
 		})
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to create pagerduty destination: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to create pagerduty destination: %v", err))
 	}
 
 	d.SetId(destination.ID)
@@ -71,21 +71,21 @@ func resourcePagerdutyDestinationImport(ctx context.Context, d *schema.ResourceD
 	project, id := ids[0], ids[1]
 	dest, err := c.GetDestination(ctx, project, id)
 	if err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("Failed to get pagerduty destination: %v", err)
+		return []*schema.ResourceData{}, fmt.Errorf("failed to get pagerduty destination: %v", err)
 	}
 
 	d.SetId(dest.ID)
 	if err := d.Set("project_name", project); err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("Unable to set project_name resource field: %v", err)
+		return []*schema.ResourceData{}, fmt.Errorf("unable to set project_name resource field: %v", err)
 	}
 
 	attributes := dest.Attributes.(map[string]interface{})
 	if err := d.Set("destination_name", attributes["name"]); err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("Unable to set destination_name resource field: %v", err)
+		return []*schema.ResourceData{}, fmt.Errorf("unable to set destination_name resource field: %v", err)
 	}
 
 	if err := d.Set("integration_key", attributes["integration_key"]); err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("Unable to set integration_key resource field: %v", err)
+		return []*schema.ResourceData{}, fmt.Errorf("unable to set integration_key resource field: %v", err)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/lightstep/resource_pagerduty_destination_test.go
+++ b/lightstep/resource_pagerduty_destination_test.go
@@ -87,7 +87,7 @@ func testAccCheckPagerdutyDestinationExists(resourceName string, destination *cl
 		}
 
 		if tfDestination.Primary.ID == "" {
-			return fmt.Errorf("iD is not set")
+			return fmt.Errorf("id is not set")
 		}
 
 		// get destination from LS

--- a/lightstep/resource_pagerduty_destination_test.go
+++ b/lightstep/resource_pagerduty_destination_test.go
@@ -3,9 +3,10 @@ package lightstep
 import (
 	"context"
 	"fmt"
-	"github.com/lightstep/terraform-provider-lightstep/client"
 	"regexp"
 	"testing"
+
+	"github.com/lightstep/terraform-provider-lightstep/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -82,11 +83,11 @@ func testAccCheckPagerdutyDestinationExists(resourceName string, destination *cl
 		// get destination from TF state
 		tfDestination, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
 		if tfDestination.Primary.ID == "" {
-			return fmt.Errorf("ID is not set")
+			return fmt.Errorf("iD is not set")
 		}
 
 		// get destination from LS
@@ -111,7 +112,7 @@ func testAccPagerdutyDestinationDestroy(s *terraform.State) error {
 		s, err := conn.GetDestination(context.Background(), test_project, resource.Primary.ID)
 		if err == nil {
 			if s.ID == resource.Primary.ID {
-				return fmt.Errorf("Destination with ID (%v) still exists.", resource.Primary.ID)
+				return fmt.Errorf("destination with ID (%v) still exists.", resource.Primary.ID)
 			}
 		}
 

--- a/lightstep/resource_slack_destination.go
+++ b/lightstep/resource_slack_destination.go
@@ -47,11 +47,11 @@ func resourceSlackDestinationRead(ctx context.Context, d *schema.ResourceData, m
 			d.SetId("")
 			return diags
 		}
-		return diag.FromErr(fmt.Errorf("Failed to get slack destination: %v\n", apiErr))
+		return diag.FromErr(fmt.Errorf("failed to get slack destination: %v", apiErr))
 	}
 
 	if err := d.Set("channel", dest.Attributes.(map[string]interface{})["channel"]); err != nil {
-		return diag.FromErr(fmt.Errorf("Unable to set channel resource field: %v", err))
+		return diag.FromErr(fmt.Errorf("unable to set channel resource field: %v", err))
 	}
 
 	return diags
@@ -70,7 +70,7 @@ func resourceSlackDestinationCreate(ctx context.Context, d *schema.ResourceData,
 
 	destination, err := c.CreateDestination(ctx, d.Get("project_name").(string), dest)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to create slack destination %v: %v", attrs.Channel, err))
+		return diag.FromErr(fmt.Errorf("failed to create slack destination %v: %v", attrs.Channel, err))
 	}
 
 	d.SetId(destination.ID)
@@ -88,17 +88,17 @@ func resourceSlackDestinationImport(ctx context.Context, d *schema.ResourceData,
 	project, id := ids[0], ids[1]
 	dest, err := c.GetDestination(ctx, project, id)
 	if err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("Failed to get slack destination: %v", err)
+		return []*schema.ResourceData{}, fmt.Errorf("failed to get slack destination: %v", err)
 	}
 
 	d.SetId(dest.ID)
 	if err := d.Set("project_name", project); err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("Unable to set project_name resource field: %v", err)
+		return []*schema.ResourceData{}, fmt.Errorf("unable to set project_name resource field: %v", err)
 	}
 
 	attributes := dest.Attributes.(map[string]interface{})
 	if err := d.Set("channel", attributes["channel"]); err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("Unable to set channel resource field: %v", err)
+		return []*schema.ResourceData{}, fmt.Errorf("unable to set channel resource field: %v", err)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/lightstep/resource_slack_destination_test.go
+++ b/lightstep/resource_slack_destination_test.go
@@ -69,7 +69,7 @@ func testAccCheckSlackDestinationExists(resourceName string, destination *client
 		}
 
 		if tfDestination.Primary.ID == "" {
-			return fmt.Errorf("iD is not set")
+			return fmt.Errorf("id is not set")
 		}
 
 		// get destination from LS

--- a/lightstep/resource_slack_destination_test.go
+++ b/lightstep/resource_slack_destination_test.go
@@ -3,8 +3,9 @@ package lightstep
 import (
 	"context"
 	"fmt"
-	"github.com/lightstep/terraform-provider-lightstep/client"
 	"testing"
+
+	"github.com/lightstep/terraform-provider-lightstep/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -64,11 +65,11 @@ func testAccCheckSlackDestinationExists(resourceName string, destination *client
 		// get destination from TF state
 		tfDestination, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
 		if tfDestination.Primary.ID == "" {
-			return fmt.Errorf("ID is not set")
+			return fmt.Errorf("iD is not set")
 		}
 
 		// get destination from LS
@@ -93,7 +94,7 @@ func testAccSlackDestinationDestroy(s *terraform.State) error {
 		d, err := conn.GetDestination(context.Background(), test_project, r.Primary.ID)
 		if err == nil {
 			if d.ID == r.Primary.ID {
-				return fmt.Errorf("Destination with ID (%v) still exists.", r.Primary.ID)
+				return fmt.Errorf("destination with ID (%v) still exists.", r.Primary.ID)
 			}
 		}
 	}

--- a/lightstep/resource_stream.go
+++ b/lightstep/resource_stream.go
@@ -67,16 +67,16 @@ func resourceStreamCreate(ctx context.Context, d *schema.ResourceData, m interfa
 		if err != nil {
 			// Fix until lock error is resolved
 			if strings.Contains(err.Error(), "Internal Server Error") {
-				return resource.RetryableError(fmt.Errorf("Expected Creation of stream but not done yet: %s", err))
+				return resource.RetryableError(fmt.Errorf("expected Creation of stream but not done yet: %s", err))
 			} else {
-				return resource.NonRetryableError(fmt.Errorf("Error creating stream: %s", err))
+				return resource.NonRetryableError(fmt.Errorf("error creating stream: %s", err))
 			}
 		}
 
 		d.SetId(stream.ID)
 		if err := resourceStreamRead(ctx, d, m); err != nil {
 			if len(err) == 0 {
-				return resource.NonRetryableError(fmt.Errorf("Failed to read stream: %v", err))
+				return resource.NonRetryableError(fmt.Errorf("failed to read stream: %v", err))
 			}
 
 			return resource.NonRetryableError(fmt.Errorf(err[0].Summary))
@@ -85,7 +85,7 @@ func resourceStreamCreate(ctx context.Context, d *schema.ResourceData, m interfa
 		d.Set("query", origQuery)
 		return nil
 	}); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to create stream: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to create stream: %v", err))
 	}
 
 	return diags
@@ -102,7 +102,7 @@ func resourceStreamRead(ctx context.Context, d *schema.ResourceData, m interface
 		if isApiErr {
 			resp := apiErr.GetHTTPResponse()
 			if resp == nil {
-				return diag.FromErr(fmt.Errorf("Failed to get stream response: %v\n", err))
+				return diag.FromErr(fmt.Errorf("failed to get stream response: %v", err))
 			}
 
 			if resp.StatusCode == http.StatusNotFound {
@@ -111,11 +111,11 @@ func resourceStreamRead(ctx context.Context, d *schema.ResourceData, m interface
 			}
 		}
 
-		return diag.FromErr(fmt.Errorf("Failed to get stream: %v\n", err))
+		return diag.FromErr(fmt.Errorf("failed to get stream: %v", err))
 	}
 
 	if err := setResourceDataFromStream(d, *s); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to set stream from API response to terraform state: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to set stream from API response to terraform state: %v", err))
 	}
 
 	return diags
@@ -133,7 +133,7 @@ func resourceStreamUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 	s.Attributes.CustomData = client.CustomDataConvert(d.Get("custom_data").([]interface{}))
 
 	if _, err := c.UpdateStream(ctx, d.Get("project_name").(string), d.Id(), s); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to update stream: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to update stream: %v", err))
 	}
 
 	return resourceStreamRead(ctx, d, m)
@@ -144,7 +144,7 @@ func resourceStreamDelete(ctx context.Context, d *schema.ResourceData, m interfa
 
 	c := m.(*client.Client)
 	if err := c.DeleteStream(ctx, d.Get("project_name").(string), d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to detele stream: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to detele stream: %v", err))
 	}
 
 	// d.SetId("") is automatically called assuming delete returns no errors, but
@@ -158,22 +158,22 @@ func resourceStreamImport(ctx context.Context, d *schema.ResourceData, m interfa
 
 	ids := strings.Split(d.Id(), ".")
 	if len(ids) != 2 {
-		return []*schema.ResourceData{}, fmt.Errorf("Error importing lightstep_stream. Expecting an  ID formed as '<lightstep_project>.<stream_id>'. Got: %v", d.Id())
+		return []*schema.ResourceData{}, fmt.Errorf("error importing lightstep_stream. Expecting an  ID formed as '<lightstep_project>.<stream_id>'. Got: %v", d.Id())
 	}
 
 	project, id := ids[0], ids[1]
 	stream, err := c.GetStream(ctx, project, id)
 	if err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("Failed to get stream: %v", err)
+		return []*schema.ResourceData{}, fmt.Errorf("failed to get stream: %v", err)
 	}
 
 	d.SetId(id)
 	if err := d.Set("project_name", project); err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("Unable to set project_name resource field: %v", err)
+		return []*schema.ResourceData{}, fmt.Errorf("unable to set project_name resource field: %v", err)
 	}
 
 	if err := setResourceDataFromStream(d, *stream); err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("Failed to set stream from API response to terraform state: %v", err)
+		return []*schema.ResourceData{}, fmt.Errorf("failed to set stream from API response to terraform state: %v", err)
 	}
 	d.Set("query", stream.Attributes.Query)
 
@@ -182,7 +182,7 @@ func resourceStreamImport(ctx context.Context, d *schema.ResourceData, m interfa
 
 func setResourceDataFromStream(d *schema.ResourceData, s client.Stream) error {
 	if err := d.Set("stream_name", s.Attributes.Name); err != nil {
-		return fmt.Errorf("Unable to set stream_name resource field: %v", err)
+		return fmt.Errorf("unable to set stream_name resource field: %v", err)
 	}
 
 	// Convert custom_data to list
@@ -223,7 +223,7 @@ func setResourceDataFromStream(d *schema.ResourceData, s client.Stream) error {
 	}
 
 	if err := d.Set("custom_data", customData); err != nil {
-		return fmt.Errorf("Unable to set custom_data resource field: %v", err)
+		return fmt.Errorf("unable to set custom_data resource field: %v", err)
 	}
 
 	// don't set query here to avoid backend normalization issue

--- a/lightstep/resource_stream_condition.go
+++ b/lightstep/resource_stream_condition.go
@@ -60,12 +60,12 @@ func resourceStreamConditionCreate(ctx context.Context, d *schema.ResourceData, 
 		d.Get("evaluation_window_ms").(int),
 		d.Get("stream_id").(string))
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to create stream condition: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to create stream condition: %v", err))
 	}
 
 	d.SetId(condition.ID)
 	if err := setResourceDataFromStreamCondition(d, condition); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to set stream condition response from API to terraform state: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to set stream condition response from API to terraform state: %v", err))
 	}
 
 	return diags
@@ -82,11 +82,11 @@ func resourceStreamConditionRead(ctx context.Context, d *schema.ResourceData, m 
 			d.SetId("")
 			return diags
 		}
-		return diag.FromErr(fmt.Errorf("Failed to get stream condition: %v\n", apiErr))
+		return diag.FromErr(fmt.Errorf("failed to get stream condition: %v", apiErr))
 	}
 
 	if err := setResourceDataFromStreamCondition(d, *condition); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to set stream condition response from API to terraform state: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to set stream condition response from API to terraform state: %v", err))
 	}
 
 	return diags
@@ -97,7 +97,7 @@ func resourceStreamConditionDelete(ctx context.Context, d *schema.ResourceData, 
 
 	c := m.(*client.Client)
 	if err := c.DeleteStreamCondition(ctx, d.Get("project_name").(string), d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to delete stream condition: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to delete stream condition: %v", err))
 	}
 
 	return diags
@@ -115,11 +115,11 @@ func resourceStreamConditionUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	condition, err := c.UpdateStreamCondition(ctx, d.Get("project_name").(string), d.Id(), attrs)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to update stream condition: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to update stream condition: %v", err))
 	}
 
 	if err := setResourceDataFromStreamCondition(d, *condition); err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to set stream condition from API response to terraform state: %v", err))
+		return diag.FromErr(fmt.Errorf("failed to set stream condition from API response to terraform state: %v", err))
 	}
 
 	return diags
@@ -130,7 +130,7 @@ func resourceStreamConditionImport(ctx context.Context, d *schema.ResourceData, 
 
 	ids := strings.Split(d.Id(), ".")
 	if len(ids) != 2 {
-		return []*schema.ResourceData{}, fmt.Errorf("Error importing lightstep_condition. Expecting an  ID formed as '<lightstep_project>.<lightstep_condition_ID>'")
+		return []*schema.ResourceData{}, fmt.Errorf("error importing lightstep_condition. Expecting an  ID formed as '<lightstep_project>.<lightstep_condition_ID>'")
 	}
 
 	project, id := ids[0], ids[1]

--- a/lightstep/resource_stream_condition_test.go
+++ b/lightstep/resource_stream_condition_test.go
@@ -137,7 +137,7 @@ func testAccCheckStreamConditionExists(resourceName string, condition *client.St
 		}
 
 		if tfCondition.Primary.ID == "" {
-			return fmt.Errorf("iD is not set")
+			return fmt.Errorf("id is not set")
 		}
 
 		c := testAccProvider.Meta().(*client.Client)

--- a/lightstep/resource_stream_condition_test.go
+++ b/lightstep/resource_stream_condition_test.go
@@ -3,9 +3,10 @@ package lightstep
 import (
 	"context"
 	"fmt"
-	"github.com/lightstep/terraform-provider-lightstep/client"
 	"regexp"
 	"testing"
+
+	"github.com/lightstep/terraform-provider-lightstep/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -132,11 +133,11 @@ func testAccCheckStreamConditionExists(resourceName string, condition *client.St
 	return func(s *terraform.State) error {
 		tfCondition, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
 		if tfCondition.Primary.ID == "" {
-			return fmt.Errorf("ID is not set")
+			return fmt.Errorf("iD is not set")
 		}
 
 		c := testAccProvider.Meta().(*client.Client)
@@ -162,7 +163,7 @@ func testAccStreamConditionDestroy(s *terraform.State) error {
 		s, err := conn.GetStreamCondition(context.Background(), test_project, resource.Primary.ID)
 		if err == nil {
 			if s.ID == resource.Primary.ID {
-				return fmt.Errorf("Condition with ID (%v) still exists.", resource.Primary.ID)
+				return fmt.Errorf("condition with ID (%v) still exists.", resource.Primary.ID)
 			}
 		}
 	}

--- a/lightstep/resource_stream_dashboard.go
+++ b/lightstep/resource_stream_dashboard.go
@@ -73,7 +73,7 @@ func resourceStreamDashboardRead(ctx context.Context, d *schema.ResourceData, m 
 			d.SetId("")
 			return diags
 		}
-		return diag.FromErr(fmt.Errorf("failed to get stream dashboard for [project: %v; resource_id: %v]: %v\n", projectName, resourceId, apiErr))
+		return diag.FromErr(fmt.Errorf("failed to get stream dashboard for [project: %v; resource_id: %v]: %v", projectName, resourceId, apiErr))
 	}
 
 	if err := setResourceDataFromStreamDashboard(d, *dashboard); err != nil {

--- a/lightstep/resource_stream_dashboard_test.go
+++ b/lightstep/resource_stream_dashboard_test.go
@@ -115,11 +115,11 @@ func testAccCheckStreamDashboardExists(resourceName string, dashboard *client.Da
 		// get dashboard from TF state
 		tfStream, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
 		if tfStream.Primary.ID == "" {
-			return fmt.Errorf("ID is not set")
+			return fmt.Errorf("iD is not set")
 		}
 
 		// get dashboard from LS
@@ -147,7 +147,7 @@ func testAccStreamDashboardDestroy(s *terraform.State) error {
 		s, err := conn.GetDashboard(context.Background(), test_project, resource.Primary.ID)
 		if err == nil {
 			if s.ID == resource.Primary.ID {
-				return fmt.Errorf("Dashboard with ID (%v) still exists.", resource.Primary.ID)
+				return fmt.Errorf("dashboard with ID (%v) still exists.", resource.Primary.ID)
 			}
 		}
 

--- a/lightstep/resource_stream_dashboard_test.go
+++ b/lightstep/resource_stream_dashboard_test.go
@@ -119,7 +119,7 @@ func testAccCheckStreamDashboardExists(resourceName string, dashboard *client.Da
 		}
 
 		if tfStream.Primary.ID == "" {
-			return fmt.Errorf("iD is not set")
+			return fmt.Errorf("id is not set")
 		}
 
 		// get dashboard from LS

--- a/lightstep/resource_stream_test.go
+++ b/lightstep/resource_stream_test.go
@@ -185,7 +185,7 @@ func testAccCheckStreamExists(resourceName string, stream *client.Stream) resour
 		}
 
 		if tfStream.Primary.ID == "" {
-			return fmt.Errorf("iD is not set")
+			return fmt.Errorf("id is not set")
 		}
 
 		// get stream from LS

--- a/lightstep/resource_stream_test.go
+++ b/lightstep/resource_stream_test.go
@@ -181,11 +181,11 @@ func testAccCheckStreamExists(resourceName string, stream *client.Stream) resour
 		// get stream from TF state
 		tfStream, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
 		if tfStream.Primary.ID == "" {
-			return fmt.Errorf("ID is not set")
+			return fmt.Errorf("iD is not set")
 		}
 
 		// get stream from LS
@@ -213,7 +213,7 @@ func testAccStreamDestroy(s *terraform.State) error {
 		s, err := conn.GetStream(context.Background(), test_project, resource.Primary.ID)
 		if err == nil {
 			if s.ID == resource.Primary.ID {
-				return fmt.Errorf("Stream with ID (%v) still exists.", resource.Primary.ID)
+				return fmt.Errorf("stream with ID (%v) still exists.", resource.Primary.ID)
 			}
 		}
 

--- a/lightstep/resource_webhook_destination.go
+++ b/lightstep/resource_webhook_destination.go
@@ -80,7 +80,7 @@ func resourceWebhookDestinationCreate(ctx context.Context, d *schema.ResourceDat
 	dest.Attributes = attrs
 	destination, err := c.CreateDestination(ctx, d.Get("project_name").(string), dest)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Failed to create webhook destination %s: %v", destination, err))
+		return diag.FromErr(fmt.Errorf("failed to create webhook destination %s: %v", destination, err))
 	}
 
 	d.SetId(destination.ID)
@@ -92,38 +92,38 @@ func resourceWebhookDestinationImport(ctx context.Context, d *schema.ResourceDat
 
 	ids := strings.Split(d.Id(), ".")
 	if len(ids) != 2 {
-		return []*schema.ResourceData{}, fmt.Errorf("Error importing lightstep_webhook_destination. Expecting an  ID formed as '<lightstep_project>.<lightstep_destination_ID>'")
+		return []*schema.ResourceData{}, fmt.Errorf("error importing lightstep_webhook_destination. Expecting an  ID formed as '<lightstep_project>.<lightstep_destination_ID>'")
 	}
 
 	project, id := ids[0], ids[1]
 	dest, err := c.GetDestination(ctx, project, id)
 	if err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("Failed to get webhook destination: %v", err)
+		return []*schema.ResourceData{}, fmt.Errorf("failed to get webhook destination: %v", err)
 	}
 
 	d.SetId(dest.ID)
 	if err := d.Set("project_name", project); err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("Unable to set project_name resource field: %v", err)
+		return []*schema.ResourceData{}, fmt.Errorf("unable to set project_name resource field: %v", err)
 	}
 
 	attributes := dest.Attributes.(map[string]interface{})
 	if err := d.Set("destination_name", attributes["name"]); err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("Unable to set destination_name resource field: %v", err)
+		return []*schema.ResourceData{}, fmt.Errorf("unable to set destination_name resource field: %v", err)
 	}
 
 	if err := d.Set("url", attributes["url"]); err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("Unable to set url resource field: %v", err)
+		return []*schema.ResourceData{}, fmt.Errorf("unable to set url resource field: %v", err)
 	}
 
 	if attributes["template"] != nil && len(attributes["template"].(string)) > 0 {
 		if err := d.Set("template", attributes["template"]); err != nil {
-			return []*schema.ResourceData{}, fmt.Errorf("Unable to set template resource field: %v", err)
+			return []*schema.ResourceData{}, fmt.Errorf("unable to set template resource field: %v", err)
 		}
 	}
 
 	if len(attributes["custom_headers"].(map[string]interface{})) > 0 {
 		if err := d.Set("custom_headers", attributes["custom_headers"]); err != nil {
-			return []*schema.ResourceData{}, fmt.Errorf("Unable to set custom_headers resource field: %v", err)
+			return []*schema.ResourceData{}, fmt.Errorf("unable to set custom_headers resource field: %v", err)
 		}
 	}
 

--- a/lightstep/resource_webhook_destination_test.go
+++ b/lightstep/resource_webhook_destination_test.go
@@ -94,7 +94,7 @@ func testAccCheckWebhookDestinationExists(resourceName string, destination *clie
 		}
 
 		if tfDestination.Primary.ID == "" {
-			return fmt.Errorf("iD is not set")
+			return fmt.Errorf("id is not set")
 		}
 
 		// get destination from LS

--- a/lightstep/resource_webhook_destination_test.go
+++ b/lightstep/resource_webhook_destination_test.go
@@ -3,9 +3,10 @@ package lightstep
 import (
 	"context"
 	"fmt"
-	"github.com/lightstep/terraform-provider-lightstep/client"
 	"regexp"
 	"testing"
+
+	"github.com/lightstep/terraform-provider-lightstep/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -89,11 +90,11 @@ func testAccCheckWebhookDestinationExists(resourceName string, destination *clie
 		// get destination from TF state
 		tfDestination, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
 		if tfDestination.Primary.ID == "" {
-			return fmt.Errorf("ID is not set")
+			return fmt.Errorf("iD is not set")
 		}
 
 		// get destination from LS
@@ -118,7 +119,7 @@ func testAccWebhookDestinationDestroy(s *terraform.State) error {
 		s, err := conn.GetDestination(context.Background(), test_project, resource.Primary.ID)
 		if err == nil {
 			if s.ID == resource.Primary.ID {
-				return fmt.Errorf("Destination with ID (%v) still exists.", resource.Primary.ID)
+				return fmt.Errorf("destination with ID (%v) still exists.", resource.Primary.ID)
 			}
 		}
 


### PR DESCRIPTION
# Why are you making this change?

Fixes a number of cosmetic Go lint warnings:

* Errors should start with lowercase letters
* Errors should not end in a newline
* Unused test functions

Not an essential change, but it keeps the style consistent and removes warnings which can be distracting during development.