### PR TITLE
[LS-36318] add escapeTQLQuery to fix newlines in TQL queries

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -32,7 +32,7 @@ resource "lightstep_metric_dashboard" "exported_dashboard" {
          latency_percentiles = [{{range .SpansQuery.LatencyPercentiles}}{{.}},{{end}}]{{end}}
       }
 {{end}}{{if .TQLQuery}}
-      tql                 = "{{.TQLQuery}}"
+      tql                 = {{escapeTQLQuery .TQLQuery}}
 {{end}}{{if .Query.Metric}}
       metric              = "{{.Query.Metric}}"
       timeseries_operator = "{{.Query.TimeseriesOperator}}"
@@ -59,6 +59,10 @@ resource "lightstep_metric_dashboard" "exported_dashboard" {
 
 func escapeSpanQuery(input string) string {
 	return strings.Replace(input, "\"", "\\\"", -1)
+}
+
+func escapeTQLQuery(input string) string {
+	return "<<EOT\n" + input + "\nEOT"
 }
 
 func Run(args ...string) error {
@@ -93,6 +97,7 @@ func Run(args ...string) error {
 
 	t := template.New("").Funcs(template.FuncMap{
 		"escapeSpanQuery": escapeSpanQuery,
+		"escapeTQLQuery":  escapeTQLQuery,
 	})
 
 	t, err = t.Parse(dashboardTemplate)


### PR DESCRIPTION
BEFORE
```
  chart {
    name = "Restarts"
    rank = "6"
    type = "timeseries"

    query {
      query_name          = "a"
      display             = "bar"
      hidden              = false

      tql                 = "metric kubernetes.containers.restarts
| filter kube_app = tqlmixer && kube_container_name != metricproxy-sidecar
| latest 1m, 1m
| group_by [kube_container_name, kube_instance, kube_namespace, pod_name], max
| delta
| point (value + pow(pow(value, 2), .5)) / 2
"

    }

  }
```


AFTER
```
  chart {
    name = "Restarts"
    rank = "6"
    type = "timeseries"

    query {
      query_name          = "a"
      display             = "bar"
      hidden              = false

      query_string                 = <<EOT
metric kubernetes.containers.restarts
| filter kube_app = tqlmixer && kube_container_name != metricproxy-sidecar
| latest 1m, 1m
| group_by [kube_container_name, kube_instance, kube_namespace, pod_name], max
| delta
| point (value + pow(pow(value, 2), .5)) / 2

EOT

    }

  }
```