### PR TITLE
feat: allow LIGHTSTEP_API_BASE_URL to override API host

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -17,3 +17,10 @@ func TestNew_other(t *testing.T) {
 	c := NewClient("api-key", "org-name", "other")
 	assert.Equal(t, "https://api-other.lightstep.com/public/v0.2/org-name", c.baseURL)
 }
+
+func TestNew_env_var_provided_baseURL(t *testing.T) {
+	// Parallel not used here due to t.Setenv.
+	t.Setenv("LIGHTSTEP_API_BASE_URL", "http://localhost:8080")
+	c := NewClient("api-key", "org-name", "public")
+	assert.Equal(t, "http://localhost:8080/public/v0.2/org-name", c.baseURL)
+}


### PR DESCRIPTION
This introduces an env var, `LIGHTSTEP_API_BASE_URL` to allow the operator to override the base URL used by the API client.

I broke up the construction a bit so we're not expecting that env var to know the full API path and org name. I feel like we should separate those two. This way the provider could say use different versions (paths) of the API for different operations, and this var never needs to change. I don't feel strongly here though...
