### PR TITLE
Do not set tql field as computed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ ifndef LIGHTSTEP_API_KEY_PUBLIC
 endif
 	@TF_ACC=true LIGHTSTEP_API_KEY=${LIGHTSTEP_API_KEY_PUBLIC} LIGHTSTEP_ORG="LightStep" LIGHTSTEP_ENV="public" go test -v ./lightstep
 
-tmp-test:
-	@TF_ACC=true LIGHTSTEP_API_KEY=${LIGHTSTEP_PUBLIC_API_KEY} LIGHTSTEP_ORG="LightStep" LIGHTSTEP_ENV="public" go test -v ./lightstep -run TestAccSpanErrorRatioCondition
-
 
 .PHONY: ensure-clean-repo
 ensure-clean-repo:

--- a/lightstep/resource_metric_condition.go
+++ b/lightstep/resource_metric_condition.go
@@ -281,7 +281,7 @@ func getMetricQuerySchema() map[string]*schema.Schema {
 			Description: "Deprecated, use the query_string field in lightstep_dashboard or lightstep_alert instead",
 			Type:        schema.TypeString,
 			Optional:    true,
-			Computed:    true,
+			Computed:    false,
 		},
 		"spans": getSpansQuerySchema(),
 	}

--- a/lightstep/resource_metric_condition_test.go
+++ b/lightstep/resource_metric_condition_test.go
@@ -717,7 +717,7 @@ resource "lightstep_metric_condition" "test" {
 				Config: updatedConditionConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetricConditionExists(resourceName, &condition),
-					resource.TestCheckResourceAttr(resourceName, "metric_query.0.tql", "spans count | rate 1h, 1h | filter (service == \"frontend\") | group_by [], sum | point (value + value) | reduce 30s, min"),
+					resource.TestCheckResourceAttr(resourceName, "metric_query.0.tql", "spans count | rate 1h, 1h | filter (service == \"frontend\") | group_by [], sum | point ((value + value) + value) | reduce 30s, min"),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/lightstep/resource_metric_condition_test.go
+++ b/lightstep/resource_metric_condition_test.go
@@ -353,7 +353,7 @@ resource "lightstep_metric_condition" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetricConditionExists(resourceName, &condition),
 					resource.TestCheckResourceAttr(resourceName, "name", "Span latency alert - updated"),
-					resource.TestCheckResourceAttr(resourceName, "metric_query.0.tql", "spans latency | delta 1h, 1h | filter (service == \"frontend\") | group_by [], sum | point percentile(value, 50.0) | reduce 30s, min"),
+					resource.TestCheckResourceAttr(resourceName, "metric_query.0.tql", "spans latency | delta 1h, 1h | filter (service == \"frontend\") | group_by [], sum | point percentile(value, 95.0) | reduce 30s, min"),
 				),
 				ExpectNonEmptyPlan: true,
 			},


### PR DESCRIPTION
Corrects the `tql` field to be not `computed`.

This fixes the failing ACC tests.