### PR TITLE
add deprecation notice to lightstep_metric_condition

### DIFF
--- a/docs/resources/metric_condition.md
+++ b/docs/resources/metric_condition.md
@@ -6,6 +6,8 @@ description: |-
 
 ---
 
+# NOTE: this resource will be deprecated in v2+. Use `lightstep_alert` instead.
+
 # lightstep_metric_condition (Resource)
 
 Provides a Lightstep Metric Condition. This can be used to create and manage Lightstep Metric Conditions that can contain either

--- a/templates/resources/metric_condition.md.tmpl
+++ b/templates/resources/metric_condition.md.tmpl
@@ -6,6 +6,8 @@ description: |-
 
 ---
 
+# NOTE: this resource will be deprecated in v2+. Use `lightstep_alert` instead.
+
 # lightstep_metric_condition (Resource)
 
 Provides a Lightstep Metric Condition. This can be used to create and manage Lightstep Metric Conditions that can contain either


### PR DESCRIPTION
`lightstep_metric_condition` is going away in favor of `lightstep_alert`, adds a notice to that effect (mirroring the one for [lightstep_metric_dashboard](https://registry.terraform.io/providers/lightstep/lightstep/latest/docs/resources/metric_dashboard))