### PR TITLE
LS-42929 add support for composite alerts

### DIFF
--- a/client/metric_conditions.go
+++ b/client/metric_conditions.go
@@ -14,13 +14,25 @@ type UnifiedCondition struct {
 }
 
 type UnifiedConditionAttributes struct {
-	Name          string                      `json:"name"`
-	Description   string                      `json:"description"`
-	Labels        []Label                     `json:"labels"`
-	Type          string                      `json:"condition_type"`
-	Expression    Expression                  `json:"expression"`
-	Queries       []MetricQueryWithAttributes `json:"metric-queries"`
-	AlertingRules []AlertingRule              `json:"alerting-rules,omitempty"`
+	Name           string                      `json:"name"`
+	Description    string                      `json:"description"`
+	Labels         []Label                     `json:"labels"`
+	Type           string                      `json:"condition_type"`
+	Expression     *Expression                 `json:"expression,omitempty"`
+	Queries        []MetricQueryWithAttributes `json:"metric-queries"`
+	AlertingRules  []AlertingRule              `json:"alerting-rules,omitempty"`
+	CompositeAlert *CompositeAlert             `json:"composite-alert,omitempty"`
+}
+
+type CompositeAlert struct {
+	Alerts []CompositeSubAlert `json:"alerts"`
+}
+
+type CompositeSubAlert struct {
+	Name       string                      `json:"name"`
+	Title      string                      `json:"title"`
+	Expression SubAlertExpression          `json:"expression"`
+	Queries    []MetricQueryWithAttributes `json:"queries"`
 }
 
 type AlertingRule struct {

--- a/client/metric_conditions.go
+++ b/client/metric_conditions.go
@@ -135,18 +135,7 @@ func (c *Client) CreateUnifiedCondition(
 		resp Envelope
 	)
 
-	bytes, err := json.Marshal(UnifiedCondition{
-		Type: condition.Type,
-		Attributes: UnifiedConditionAttributes{
-			Name:          condition.Attributes.Name,
-			Type:          condition.Type,
-			Expression:    condition.Attributes.Expression,
-			Queries:       condition.Attributes.Queries,
-			AlertingRules: condition.Attributes.AlertingRules,
-			Description:   condition.Attributes.Description,
-			Labels:        condition.Attributes.Labels,
-		},
-	})
+	bytes, err := json.Marshal(condition)
 
 	if err != nil {
 		return cond, err

--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -46,21 +46,99 @@ EOT
 
 ### Required
 
-- `expression` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--expression))
 - `name` (String)
 - `project_name` (String)
-- `query` (Block List, Min: 1) (see [below for nested schema](#nestedblock--query))
 
 ### Optional
 
 - `alerting_rule` (Block Set) (see [below for nested schema](#nestedblock--alerting_rule))
+- `composite_alert` (Block List, Max: 1) (see [below for nested schema](#nestedblock--composite_alert))
 - `description` (String)
+- `expression` (Block List, Max: 1) (see [below for nested schema](#nestedblock--expression))
 - `label` (Block Set) Labels can be key/value pairs or standalone values. (see [below for nested schema](#nestedblock--label))
+- `query` (Block List) (see [below for nested schema](#nestedblock--query))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 - `type` (String)
+
+<a id="nestedblock--alerting_rule"></a>
+### Nested Schema for `alerting_rule`
+
+Required:
+
+- `update_interval` (String)
+
+Optional:
+
+- `exclude_filters` (List of Map of String)
+- `filters` (List of Map of String) Non-equality filters (operand: contains, regexp, etc)
+- `include_filters` (List of Map of String)
+
+Read-Only:
+
+- `id` (String) The ID of this resource.
+
+
+<a id="nestedblock--composite_alert"></a>
+### Nested Schema for `composite_alert`
+
+Required:
+
+- `alert` (Block Set, Min: 1, Max: 10) (see [below for nested schema](#nestedblock--composite_alert--alert))
+
+<a id="nestedblock--composite_alert--alert"></a>
+### Nested Schema for `composite_alert.alert`
+
+Required:
+
+- `expression` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--composite_alert--alert--expression))
+- `name` (String)
+- `query` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--composite_alert--alert--query))
+
+Optional:
+
+- `title` (String)
+
+<a id="nestedblock--composite_alert--alert--expression"></a>
+### Nested Schema for `composite_alert.alert.expression`
+
+Required:
+
+- `operand` (String)
+- `thresholds` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--composite_alert--alert--expression--thresholds))
+
+Optional:
+
+- `is_no_data` (Boolean)
+
+<a id="nestedblock--composite_alert--alert--expression--thresholds"></a>
+### Nested Schema for `composite_alert.alert.expression.thresholds`
+
+Optional:
+
+- `critical` (String)
+- `warning` (String)
+
+
+
+<a id="nestedblock--composite_alert--alert--query"></a>
+### Nested Schema for `composite_alert.alert.query`
+
+Required:
+
+- `hidden` (Boolean)
+- `query_name` (String)
+- `query_string` (String)
+
+Optional:
+
+- `display` (String)
+- `hidden_queries` (Map of String) An optional map of sub-query names in the query_string to a boolean string to hide/show that query. If specified, the map must have an entry for all named sub-queries in the query_string. A value of "true" indicates the query should be hidden. Example: `hidden_queries = {  "a" = "true",  "b" = "false" }`.
+
+
+
 
 <a id="nestedblock--expression"></a>
 ### Nested Schema for `expression`
@@ -85,6 +163,18 @@ Optional:
 
 
 
+<a id="nestedblock--label"></a>
+### Nested Schema for `label`
+
+Required:
+
+- `value` (String)
+
+Optional:
+
+- `key` (String)
+
+
 <a id="nestedblock--query"></a>
 ### Nested Schema for `query`
 
@@ -98,33 +188,3 @@ Optional:
 
 - `display` (String)
 - `hidden_queries` (Map of String) An optional map of sub-query names in the query_string to a boolean string to hide/show that query. If specified, the map must have an entry for all named sub-queries in the query_string. A value of "true" indicates the query should be hidden. Example: `hidden_queries = {  "a" = "true",  "b" = "false" }`.
-
-
-<a id="nestedblock--alerting_rule"></a>
-### Nested Schema for `alerting_rule`
-
-Required:
-
-- `update_interval` (String)
-
-Optional:
-
-- `exclude_filters` (List of Map of String)
-- `filters` (List of Map of String) Non-equality filters (operand: contains, regexp, etc)
-- `include_filters` (List of Map of String)
-
-Read-Only:
-
-- `id` (String) The ID of this resource.
-
-
-<a id="nestedblock--label"></a>
-### Nested Schema for `label`
-
-Required:
-
-- `value` (String)
-
-Optional:
-
-- `key` (String)

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -121,9 +121,9 @@ resource "lightstep_metric_condition" "beemo_requests" {
   name         = "Beemo Low Requests"
 
   expression {
-    is_multi            = true
-    is_no_data          = true
-    operand             = "below"
+    is_multi   = true
+    is_no_data = true
+    operand    = "below"
     thresholds {
       warning  = 10.0
       critical = 5.0
@@ -184,68 +184,68 @@ resource "lightstep_metric_condition" "beemo_requests" {
 # Composite alert
 
 resource "lightstep_alert" "beemo_composite_alert" {
- project_name = var.project
- name = "Beemo Too many requests & failures"
- description = "A link to a playbook"
+  project_name = var.project
+  name         = "Beemo Too many requests & failures"
+  description  = "A link to a playbook"
 
- composite_alert {
-   alert {
-     name = "A"
-     title = "Too many requests"
-     expression {
-       is_no_data = false
-       operand  = "above"
-       thresholds {
-         critical  = 10
-         warning = 5
-       }
-     }
-
-     query {
-       query_name          = "a"
-       hidden              = false
-       query_string        = "metric requests | rate 1h, 30s | filter \"project_name\" == \"BEEMO\" && \"service\" != \"android\" | group_by[\"method\"], mean | reduce 30s, min"
-     }
-   }
-
-   alert {
-     name = "B"
-     title = "Too many failures"
-     expression {
-       is_no_data = false
-       operand  = "above"
-       thresholds {
-          critical  = 10
-          warning = 5
+  composite_alert {
+    alert {
+      name  = "A"
+      title = "Too many requests"
+      expression {
+        is_no_data = false
+        operand    = "above"
+        thresholds {
+          critical = 10
+          warning  = 5
         }
-     }
-     query {
-       query_name          = "a"
-       hidden              = false
-       query_string        = "metric failures | rate 1h, 30s | filter \"project_name\" == \"BEEMO\" && \"service\" != \"android\" | group_by[\"method\"], mean | reduce 30s, min"
-     }
-   }
- }
+      }
 
- alerting_rule {
-   id          = lightstep_slack_destination.slack.id
-   update_interval = "1h"
+      query {
+        query_name   = "a"
+        hidden       = false
+        query_string = "metric requests | rate 1h, 30s | filter \"project_name\" == \"BEEMO\" && \"service\" != \"android\" | group_by[\"method\"], mean | reduce 30s, min"
+      }
+    }
 
-   include_filters = [
-     {
-       key   = "project_name"
-       value = "BEEMO"
-     }
-   ]
+    alert {
+      name  = "B"
+      title = "Too many failures"
+      expression {
+        is_no_data = false
+        operand    = "above"
+        thresholds {
+          critical = 10
+          warning  = 5
+        }
+      }
+      query {
+        query_name   = "a"
+        hidden       = false
+        query_string = "metric failures | rate 1h, 30s | filter \"project_name\" == \"BEEMO\" && \"service\" != \"android\" | group_by[\"method\"], mean | reduce 30s, min"
+      }
+    }
+  }
 
-   filters = [
-     {
-       key   = "service_name"
-       value = "frontend"
-       operand = "contains"
-     }
-   ]
- }
+  alerting_rule {
+    id              = lightstep_slack_destination.slack.id
+    update_interval = "1h"
+
+    include_filters = [
+      {
+        key   = "project_name"
+        value = "BEEMO"
+      }
+    ]
+
+    filters = [
+      {
+        key     = "service_name"
+        value   = "frontend"
+        operand = "contains"
+      }
+    ]
+  }
 }
 
 ##############################################################

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -121,8 +121,6 @@ resource "lightstep_metric_condition" "beemo_requests" {
   name         = "Beemo Low Requests"
 
   expression {
-    evaluation_window   = "2m"
-    evaluation_criteria = "on_average"
     is_multi            = true
     is_no_data          = true
     operand             = "below"

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -184,47 +184,49 @@ resource "lightstep_metric_condition" "beemo_requests" {
 }
 
 # Composite alert
+
 resource "lightstep_alert" "beemo_composite_alert" {
  project_name = var.project
  name = "Beemo Too many requests & failures"
  description = "A link to a playbook"
 
  composite_alert {
-     alert {
-       name = "A"
-       title = "Too many requests"
-       expression {
-	     is_no_data = false
-         operand  = "above"
-         thresholds {
-	    	critical  = 10
-	    	warning = 5
-	      }
-       }
-       query {
-         query_name          = "a"
-         hidden              = false
-	     query_string        = "metric requests | rate 1h, 30s | filter \"project_name\" == \"BEEMO\" && \"service\" != \"android\" | group_by[\"method\"], mean | reduce 30s, min"
+   alert {
+     name = "A"
+     title = "Too many requests"
+     expression {
+       is_no_data = false
+       operand  = "above"
+       thresholds {
+         critical  = 10
+         warning = 5
        }
      }
 
-     alert {
-       name = "B"
-       title = "Too many failures"
-       expression {
-	      is_no_data = false
-         operand  = "above"
-         thresholds {
-	    	critical  = 10
-	    	warning = 5
-	      }
-       }
-       query {
-         query_name          = "a"
-         hidden              = false
-	      query_string        = "metric failures | rate 1h, 30s | filter \"project_name\" == \"BEEMO\" && \"service\" != \"android\" | group_by[\"method\"], mean | reduce 30s, min"
-       }
+     query {
+       query_name          = "a"
+       hidden              = false
+       query_string        = "metric requests | rate 1h, 30s | filter \"project_name\" == \"BEEMO\" && \"service\" != \"android\" | group_by[\"method\"], mean | reduce 30s, min"
      }
+   }
+
+   alert {
+     name = "B"
+     title = "Too many failures"
+     expression {
+       is_no_data = false
+       operand  = "above"
+       thresholds {
+          critical  = 10
+          warning = 5
+        }
+     }
+     query {
+       query_name          = "a"
+       hidden              = false
+       query_string        = "metric failures | rate 1h, 30s | filter \"project_name\" == \"BEEMO\" && \"service\" != \"android\" | group_by[\"method\"], mean | reduce 30s, min"
+     }
+   }
  }
 
  alerting_rule {

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -183,6 +183,71 @@ resource "lightstep_metric_condition" "beemo_requests" {
 
 }
 
+# Composite alert
+resource "lightstep_alert" "beemo_composite_alert" {
+ project_name = var.project
+ name = "Beemo Too many requests & failures"
+ description = "A link to a playbook"
+
+ composite_alert {
+     alert {
+       name = "A"
+       title = "Too many requests"
+       expression {
+	     is_no_data = false
+         operand  = "above"
+         thresholds {
+	    	critical  = 10
+	    	warning = 5
+	      }
+       }
+       query {
+         query_name          = "a"
+         hidden              = false
+	     query_string        = "metric requests | rate 1h, 30s | filter \"project_name\" == \"BEEMO\" && \"service\" != \"android\" | group_by[\"method\"], mean | reduce 30s, min"
+       }
+     }
+
+     alert {
+       name = "B"
+       title = "Too many failures"
+       expression {
+	      is_no_data = false
+         operand  = "above"
+         thresholds {
+	    	critical  = 10
+	    	warning = 5
+	      }
+       }
+       query {
+         query_name          = "a"
+         hidden              = false
+	      query_string        = "metric failures | rate 1h, 30s | filter \"project_name\" == \"BEEMO\" && \"service\" != \"android\" | group_by[\"method\"], mean | reduce 30s, min"
+       }
+     }
+ }
+
+ alerting_rule {
+   id          = lightstep_slack_destination.slack.id
+   update_interval = "1h"
+
+   include_filters = [
+     {
+       key   = "project_name"
+       value = "BEEMO"
+     }
+   ]
+
+	filters = [
+		{
+		  key   = "service_name"
+		  value = "frontend"
+		  operand = "contains"
+		}
+	  ]
+ }
+}
+
 ##############################################################
 ## Destinations
 ##############################################################

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -240,13 +240,13 @@ resource "lightstep_alert" "beemo_composite_alert" {
      }
    ]
 
-	filters = [
-		{
-		  key   = "service_name"
-		  value = "frontend"
-		  operand = "contains"
-		}
-	  ]
+   filters = [
+     {
+       key   = "service_name"
+       value = "frontend"
+       operand = "contains"
+     }
+   ]
  }
 }
 

--- a/lightstep/resource_alert_test.go
+++ b/lightstep/resource_alert_test.go
@@ -170,8 +170,6 @@ resource "lightstep_metric_condition" "errors" {
   project_name = "terraform-provider-tests"
   name = "Too many requests"
   expression {
-	  evaluation_window   = "2m"
-	  evaluation_criteria = "on_average"
 	  is_multi   = true
 	  is_no_data = true
       operand  = "above"

--- a/lightstep/resource_alert_test.go
+++ b/lightstep/resource_alert_test.go
@@ -839,7 +839,7 @@ resource "lightstep_alert" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					testAccChecLightstepAlertExists(resourceName, &compositeCondition),
 				),
-				ExpectError: regexp.MustCompile("single alert queries must not be set"),
+				ExpectError: regexp.MustCompile("single alert queries and composite alert cannot both be set"),
 			},
 			{
 				Config: compositeConditionConfig,

--- a/lightstep/resource_alert_test.go
+++ b/lightstep/resource_alert_test.go
@@ -133,7 +133,8 @@ resource "lightstep_alert" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					testAccChecLightstepAlertExists(resourceName, &condition),
 				),
-				ExpectError: regexp.MustCompile("(Missing required argument|Insufficient query blocks)"),
+				// TODO I think Matt fixed this locally yesterday
+				ExpectError: regexp.MustCompile("(Missing required argument|Insufficient query blocks|at least on query is required)"),
 			},
 			{
 				Config: conditionConfig,
@@ -630,8 +631,7 @@ resource "lightstep_alert" "test" {
  description = "A link to a playbook"
 
  composite_alert {
-   alerts = [
-     {
+     alert {
        name = "A"
        title = "Too many requests"
        expression {
@@ -648,7 +648,8 @@ resource "lightstep_alert" "test" {
 	      query_string        = "metric requests | rate 1h, 30s | filter \"project_name\" == \"catlab\" && \"service\" != \"android\" | group_by[\"method\"], mean | reduce 30s, min"
        }
      }
-     {
+     
+     alert {
        name = "B"
        title = "Too many customers"
        expression {
@@ -665,7 +666,6 @@ resource "lightstep_alert" "test" {
 	      query_string        = "metric customers | rate 1h, 30s | filter \"project_name\" == \"catlab\" && \"service\" != \"android\" | group_by[\"method\"], mean | reduce 30s, min"
        }
      }
-   ]
  }
 
  alerting_rule {
@@ -702,8 +702,7 @@ resource "lightstep_alert" "test" {
  description = "A link to a playbook"
 
  composite_alert {
-   alerts = [
-     {
+   alert {
        name = "A"
        title = "updated too many requests"
        expression {
@@ -719,8 +718,9 @@ resource "lightstep_alert" "test" {
          hidden              = false
 	      query_string        = "metric requests | rate 1h, 30s | filter \"project_name\" == \"catlab\" && \"service\" != \"android\" | group_by[\"method\"], mean | reduce 30s, min"
        }
-     }
-     {
+   }
+
+   alert {
        name = "B"
        title = "updated too many customers"
        expression {
@@ -736,8 +736,7 @@ resource "lightstep_alert" "test" {
          hidden              = false
 	      query_string        = "metric customers | rate 1h, 30s | filter \"project_name\" == \"catlab\" && \"service\" != \"android\" | group_by[\"method\"], mean | reduce 30s, min"
        }
-     }
-   ]
+   }
  }
 
  alerting_rule {

--- a/lightstep/resource_alert_test.go
+++ b/lightstep/resource_alert_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccAlert(t *testing.T) {
 	var condition client.UnifiedCondition
 
-	badCondition := `
+	badAlertMissingQueryAndCompositeFields := `
 resource "lightstep_alert" "errors" {
   project_name = "terraform-provider-tests"
   name = "Too many requests"
@@ -129,12 +129,11 @@ resource "lightstep_alert" "test" {
 		CheckDestroy: testAccMetricConditionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: badCondition,
+				Config: badAlertMissingQueryAndCompositeFields,
 				Check: resource.ComposeTestCheckFunc(
 					testAccChecLightstepAlertExists(resourceName, &condition),
 				),
-				// TODO I think Matt fixed this locally yesterday
-				ExpectError: regexp.MustCompile("(Missing required argument|Insufficient query blocks|at least on query is required)"),
+				ExpectError: regexp.MustCompile("at least one query is required"),
 			},
 			{
 				Config: conditionConfig,

--- a/lightstep/resource_metric_condition.go
+++ b/lightstep/resource_metric_condition.go
@@ -1012,7 +1012,12 @@ func buildLabelFilters(includes []interface{}, excludes []interface{}, all []int
 }
 
 func buildCompositeAlert(d *schema.ResourceData) (*client.CompositeAlert, error) {
-	compositeAlertIn := d.Get("composite_alert").([]interface{})
+	compositeAlertInUntyped := d.Get("composite_alert")
+	if compositeAlertInUntyped == nil {
+		return nil, nil
+	}
+
+	compositeAlertIn := compositeAlertInUntyped.([]interface{})
 	if len(compositeAlertIn) == 0 {
 		return nil, nil
 	}

--- a/lightstep/resource_metric_condition.go
+++ b/lightstep/resource_metric_condition.go
@@ -1178,22 +1178,13 @@ func setResourceDataFromUnifiedCondition(project string, c client.UnifiedConditi
 	}
 
 	if c.Attributes.Expression != nil {
-		thresholdEntries := map[string]interface{}{}
-		if c.Attributes.Expression.Thresholds.Critical != nil {
-			thresholdEntries["critical"] = strconv.FormatFloat(*c.Attributes.Expression.Thresholds.Critical, 'f', -1, 64)
-		}
-
-		if c.Attributes.Expression.Thresholds.Warning != nil {
-			thresholdEntries["warning"] = strconv.FormatFloat(*c.Attributes.Expression.Thresholds.Warning, 'f', -1, 64)
-		}
-
 		if err := d.Set("expression", []map[string]interface{}{
 			{
 				"is_multi":   c.Attributes.Expression.IsMulti,
 				"is_no_data": c.Attributes.Expression.IsNoData,
 				"operand":    c.Attributes.Expression.Operand,
 				"thresholds": []interface{}{
-					thresholdEntries,
+					buildUntypedThresholdsMap(c.Attributes.Expression.Thresholds),
 				},
 			},
 		}); err != nil {
@@ -1209,6 +1200,7 @@ func setResourceDataFromUnifiedCondition(project string, c client.UnifiedConditi
 		queries, err := getQueriesFromUnifiedConditionResourceData(
 			c.Attributes.Queries,
 			c.ID,
+			"",
 		)
 		if err != nil {
 			return err
@@ -1253,6 +1245,18 @@ func setResourceDataFromUnifiedCondition(project string, c client.UnifiedConditi
 	}
 
 	return nil
+}
+
+func buildUntypedThresholdsMap(thresholds client.Thresholds) map[string]interface{} {
+	outputMap := map[string]interface{}{}
+	if thresholds.Critical != nil {
+		outputMap["critical"] = strconv.FormatFloat(*thresholds.Critical, 'f', -1, 64)
+	}
+
+	if thresholds.Warning != nil {
+		outputMap["warning"] = strconv.FormatFloat(*thresholds.Warning, 'f', -1, 64)
+	}
+	return outputMap
 }
 
 func getIncludeExcludeFilters(filters []client.LabelFilter) ([]interface{}, []interface{}, []interface{}) {

--- a/lightstep/resource_metric_condition.go
+++ b/lightstep/resource_metric_condition.go
@@ -87,6 +87,7 @@ func resourceUnifiedCondition(conditionSchemaType ConditionSchemaType) *schema.R
 				Schema: getUnifiedQuerySchemaMap(),
 			},
 		}
+		// Configuration for a composite alert, consists of two or more sub alerts
 		resource.Schema["composite_alert"] = &schema.Schema{
 			Type:     schema.TypeList,
 			Optional: true,

--- a/lightstep/resource_metric_condition_test.go
+++ b/lightstep/resource_metric_condition_test.go
@@ -213,7 +213,7 @@ resource "lightstep_metric_condition" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetricConditionExists(resourceName, &condition),
 				),
-				ExpectError: regexp.MustCompile("(Missing required argument|Insufficient metric_query blocks)"),
+				ExpectError: regexp.MustCompile("at least one query is required"),
 			},
 			{
 				Config: conditionConfig,

--- a/lightstep/resource_metric_condition_test.go
+++ b/lightstep/resource_metric_condition_test.go
@@ -48,8 +48,6 @@ resource "lightstep_metric_condition" "errors" {
   project_name = "terraform-provider-tests"
   name = "Too many requests"
   expression {
-	  evaluation_window   = "2m"
-	  evaluation_criteria = "on_average"
 	  is_multi   = true
 	  is_no_data = true
       operand  = "above"

--- a/lightstep/resource_metric_condition_test.go
+++ b/lightstep/resource_metric_condition_test.go
@@ -211,7 +211,7 @@ resource "lightstep_metric_condition" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetricConditionExists(resourceName, &condition),
 				),
-				ExpectError: regexp.MustCompile("at least one query is required"),
+				ExpectError: regexp.MustCompile("(Missing required argument|Insufficient metric_query blocks)"),
 			},
 			{
 				Config: conditionConfig,


### PR DESCRIPTION
Composite alerts! In terraform!

Composite alerts allow a user to create an alert on multiple signals with their own thresholds. (Query A is above Threshold A && Query B is below Threshold B && ...)

A `lightstep_alert` resource now no longer allows an `expression` or `query` block be provided if `composite_alert` is provided. Composite alert queries must be written in UQL.