### PR TITLE
Allow empty update interval in terraform

### DIFF
--- a/lightstep/constants.go
+++ b/lightstep/constants.go
@@ -11,7 +11,6 @@ var (
 		"40m": 2400000,
 		"50m": 3000000,
 		"1h":  3600000,
-		"1":   5400000,
 		"2h":  7200000,
 		"3h":  10800000,
 		"4h":  14400000,
@@ -32,7 +31,7 @@ func GetValidUpdateInterval() []string {
 	return res
 }
 
-func GetUpdateIntervalValue(in int) string {
+func GetUpdateIntervalValue(in int) interface{} {
 	for k, v := range validUpdateInterval {
 		if v == in {
 			return k

--- a/lightstep/resource_metric_condition.go
+++ b/lightstep/resource_metric_condition.go
@@ -124,7 +124,7 @@ func getAlertingRuleSchemaMap() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"update_interval": {
 			Type:         schema.TypeString,
-			Required:     true,
+			Optional:     true,
 			ValidateFunc: validation.StringInSlice(GetValidUpdateInterval(), false),
 		},
 		"id": {
@@ -663,7 +663,10 @@ func buildAlertingRules(alertingRulesIn *schema.Set) ([]client.AlertingRule, err
 			MessageDestinationID: rule["id"].(string),
 		}
 
-		newRule.UpdateInterval = validUpdateInterval[rule["update_interval"].(string)]
+		updateIntervalMilli, ok := validUpdateInterval[rule["update_interval"].(string)]
+		if ok {
+			newRule.UpdateInterval = updateIntervalMilli
+		}
 
 		var includes []interface{}
 		var excludes []interface{}


### PR DESCRIPTION
Alerting rules are allowed to not have a notification interval, but the terraform provider had no way of setting this. This PR remedies that.