### PR TITLE
remove query_format argument

### DIFF
--- a/client/metric_dashboards.go
+++ b/client/metric_dashboards.go
@@ -71,7 +71,7 @@ type TemplateVariable struct {
 	SuggestionAttributeKey string   `json:"suggestion_attribute_key"`
 }
 
-func getUnifiedDashboardURL(project, id string, query map[string]string) string {
+func getUnifiedDashboardURL(project, id string) string {
 	path := fmt.Sprintf(
 		"projects/%s/metric_dashboards",
 		url.PathEscape(project),
@@ -80,13 +80,6 @@ func getUnifiedDashboardURL(project, id string, query map[string]string) string 
 		path += "/" + url.PathEscape(id)
 	}
 	u := url.URL{Path: path}
-	if len(query) > 0 {
-		q := u.Query()
-		for k, v := range query {
-			q.Set(k, v)
-		}
-		u.RawQuery = q.Encode()
-	}
 	return u.String()
 }
 
@@ -115,7 +108,7 @@ func (c *Client) CreateUnifiedDashboard(
 		return cond, err
 	}
 
-	url := getUnifiedDashboardURL(projectName, "", nil)
+	url := getUnifiedDashboardURL(projectName, "")
 
 	err = c.CallAPI(ctx, "POST", url, Envelope{Data: bytes}, &resp)
 	if err != nil {
@@ -129,18 +122,13 @@ func (c *Client) CreateUnifiedDashboard(
 	return cond, err
 }
 
-func (c *Client) GetUnifiedDashboard(ctx context.Context, projectName string, id string, convertToQueryString bool) (*UnifiedDashboard, error) {
+func (c *Client) GetUnifiedDashboard(ctx context.Context, projectName string, id string) (*UnifiedDashboard, error) {
 	var (
 		d    *UnifiedDashboard
 		resp Envelope
 	)
 
-	var q map[string]string
-	if convertToQueryString {
-		q = map[string]string{"query_format": "query_string"}
-	}
-
-	url := getUnifiedDashboardURL(projectName, id, q)
+	url := getUnifiedDashboardURL(projectName, id)
 	err := c.CallAPI(ctx, "GET", url, nil, &resp)
 	if err != nil {
 		return nil, err
@@ -170,7 +158,7 @@ func (c *Client) UpdateUnifiedDashboard(
 		return nil, err
 	}
 
-	url := getUnifiedDashboardURL(projectName, dashboardID, nil)
+	url := getUnifiedDashboardURL(projectName, dashboardID)
 	err = c.CallAPI(ctx, "PUT", url, Envelope{Data: bytes}, &resp)
 	if err != nil {
 		return d, err
@@ -181,7 +169,7 @@ func (c *Client) UpdateUnifiedDashboard(
 }
 
 func (c *Client) DeleteUnifiedDashboard(ctx context.Context, projectName string, dashboardID string) error {
-	url := getUnifiedDashboardURL(projectName, dashboardID, nil)
+	url := getUnifiedDashboardURL(projectName, dashboardID)
 
 	err := c.CallAPI(ctx, "DELETE", url, nil, nil)
 	if err != nil {

--- a/client/metric_dashboards_test.go
+++ b/client/metric_dashboards_test.go
@@ -13,28 +13,19 @@ import (
 func Test_getUnifiedDashboardURL(t *testing.T) {
 	testCases := []struct {
 		projID   [2]string
-		query    map[string]string
 		expected string
 	}{
 		{
-			[2]string{"my_project", "123"}, nil,
+			[2]string{"my_project", "123"},
 			"projects/my_project/metric_dashboards/123",
 		},
 		{
-			[2]string{"ProductionEnvironment", "fLx72349023"}, nil,
+			[2]string{"ProductionEnvironment", "fLx72349023"},
 			"projects/ProductionEnvironment/metric_dashboards/fLx72349023",
-		},
-		{
-			[2]string{"my_project", "123"}, map[string]string{"query_format": "query_string"},
-			"projects/my_project/metric_dashboards/123?query_format=query_string",
-		},
-		{
-			[2]string{"my_project", "123"}, map[string]string{"a": "1", "b": "2", "c": "3"},
-			"projects/my_project/metric_dashboards/123?a=1&b=2&c=3",
 		},
 	}
 	for _, c := range testCases {
-		result := getUnifiedDashboardURL(c.projID[0], c.projID[1], c.query)
+		result := getUnifiedDashboardURL(c.projID[0], c.projID[1])
 		require.Equal(t, c.expected, result)
 	}
 }

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -181,13 +181,9 @@ func Run(args ...string) error {
 	if args[2] != "dashboard" && args[2] != "lightstep_dashboard" {
 		log.Fatalf("error: only dashboard resources are supported at this time")
 	}
-	convertToQueryString := false
-	if args[2] == "lightstep_dashboard" {
-		convertToQueryString = true
-	}
 
 	c := client.NewClient(os.Getenv("LIGHTSTEP_API_KEY"), os.Getenv("LIGHTSTEP_ORG"), lightstepEnv)
-	d, err := c.GetUnifiedDashboard(context.Background(), args[3], args[4], convertToQueryString)
+	d, err := c.GetUnifiedDashboard(context.Background(), args[3], args[4])
 	if err != nil {
 		log.Fatalf("error: could not get dashboard: %v", err)
 	}

--- a/lightstep/resource_dashboard_test.go
+++ b/lightstep/resource_dashboard_test.go
@@ -670,7 +670,7 @@ func testGetMetricDashboardDestroy(s *terraform.State) error {
 			continue
 		}
 
-		s, err := conn.GetUnifiedDashboard(context.Background(), test_project, r.Primary.ID, false)
+		s, err := conn.GetUnifiedDashboard(context.Background(), test_project, r.Primary.ID)
 		if err == nil {
 			if s.ID == r.Primary.ID {
 				return fmt.Errorf("metric dashboard with ID (%v) still exists.", r.Primary.ID)
@@ -692,7 +692,7 @@ func testAccCheckMetricDashboardExists(resourceName string, dashboard *client.Un
 		}
 
 		c := testAccProvider.Meta().(*client.Client)
-		dash, err := c.GetUnifiedDashboard(context.Background(), test_project, tfDashboard.Primary.ID, false)
+		dash, err := c.GetUnifiedDashboard(context.Background(), test_project, tfDashboard.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/lightstep/resource_metric_dashboard.go
+++ b/lightstep/resource_metric_dashboard.go
@@ -334,19 +334,12 @@ func (p *resourceUnifiedDashboardImp) resourceUnifiedDashboardRead(ctx context.C
 	var diags diag.Diagnostics
 	c := m.(*client.Client)
 
-	// The lightstep_dashboard resource always wants to use query_strings rather than
-	// JSON-based queries
-	convertToQueryString := false
-	if p.chartSchemaType == UnifiedChartSchema {
-		convertToQueryString = true
-	}
-
 	prevAttrs, hasLegacyChartsIn, err := getUnifiedDashboardAttributesFromResource(d)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to translate resource attributes: %v", err))
 	}
 
-	dashboard, err := c.GetUnifiedDashboard(ctx, d.Get("project_name").(string), d.Id(), convertToQueryString)
+	dashboard, err := c.GetUnifiedDashboard(ctx, d.Get("project_name").(string), d.Id())
 	if err != nil {
 		apiErr, ok := err.(client.APIResponseCarrier)
 		if !ok {
@@ -848,13 +841,8 @@ func (p *resourceUnifiedDashboardImp) resourceUnifiedDashboardImport(ctx context
 		return []*schema.ResourceData{}, fmt.Errorf("error importing %v. Expecting an  ID formed as '<lightstep_project>.<%v_ID>'", resourceName, resourceName)
 	}
 
-	convertToQueryString := false
-	if p.chartSchemaType == UnifiedChartSchema {
-		convertToQueryString = true
-	}
-
 	project, id := ids[0], ids[1]
-	dash, err := c.GetUnifiedDashboard(ctx, project, id, convertToQueryString)
+	dash, err := c.GetUnifiedDashboard(ctx, project, id)
 	if err != nil {
 		return []*schema.ResourceData{}, fmt.Errorf("failed to get dashboard. err: %v", err)
 	}


### PR DESCRIPTION
this argument is no longer needed, as all queries are persisted in their query string format