### PR TITLE
Turn off acceptance tests for dependabot PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -105,6 +105,10 @@ jobs:
         run: make test
   acc-tests:
     runs-on: ubuntu-latest
+    ## Skip acc tests on dependabot PRs because secrets are excluded on these PRs
+    ## which in turn guarantees that the acc-tests will fail. We will rely solely on
+    ## unit tests to tell us that the dependencies are working as expected.
+    if: ${{ github.actor != 'dependabot[bot]' }}
     env:
       LIGHTSTEP_API_KEY_PUBLIC: ${{ secrets.LIGHTSTEP_API_KEY_PUBLIC }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,34 @@ on:
     tags:
       - 'v*'
 jobs:
+  acc-tests:
+    runs-on: ubuntu-latest
+    env:
+      LIGHTSTEP_API_KEY_PUBLIC: ${{ secrets.LIGHTSTEP_API_KEY_PUBLIC }}
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20.5'
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup terraform CLI
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.0.11
+          terraform_wrapper: false
+
+      - name: Compile
+        run: make
+
+      - name: Run Unit Tests
+        run: make acc-test
   goreleaser:
+    # Require that the acceptance tests pass before releasing the provider
+    needs: acc-tests
     runs-on: ubuntu-latest
     steps:
       -

--- a/lightstep/resource_servicenow_destination_test.go
+++ b/lightstep/resource_servicenow_destination_test.go
@@ -17,7 +17,7 @@ func TestAccServiceNowDestination(t *testing.T) {
 
 	missingUrlConfig := `
 resource "lightstep_servicenow_destination" "missing_url" {
-  project_name = ` + fmt.Sprintf("\"%s\"", test_project) + `
+  project_name = ` + fmt.Sprintf("\"%s\"", testProject) + `
   destination_name = "my-destination"
   auth {
     username = "me"
@@ -27,7 +27,7 @@ resource "lightstep_servicenow_destination" "missing_url" {
 `
 	missingAuthConfig := `
 resource "lightstep_servicenow_destination" "missing_auth" {
-  project_name = ` + fmt.Sprintf("\"%s\"", test_project) + `
+  project_name = ` + fmt.Sprintf("\"%s\"", testProject) + `
   destination_name = "my-destination"
   url = "https://example.com"
 }
@@ -35,7 +35,7 @@ resource "lightstep_servicenow_destination" "missing_auth" {
 
 	destinationConfig := `
 resource "lightstep_servicenow_destination" "servicenow" {
-  project_name = ` + fmt.Sprintf("\"%s\"", test_project) + `
+  project_name = ` + fmt.Sprintf("\"%s\"", testProject) + `
   destination_name = "my-destination"
   url = "https://example.com"
   auth {
@@ -101,7 +101,7 @@ resource "lightstep_servicenow_destination" "servicenow" {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"auth.0.password"},
-				ImportStateIdPrefix:     fmt.Sprintf("%s.", test_project),
+				ImportStateIdPrefix:     fmt.Sprintf("%s.", testProject),
 			},
 		},
 	})
@@ -121,7 +121,7 @@ func testAccCheckServiceNowDestinationExists(resourceName string, destination *c
 
 		// get destination from LS
 		client := testAccProvider.Meta().(*client.Client)
-		d, err := client.GetDestination(context.Background(), test_project, tfDestination.Primary.ID)
+		d, err := client.GetDestination(context.Background(), testProject, tfDestination.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -138,7 +138,7 @@ func testAccServiceNowDestinationDestroy(s *terraform.State) error {
 			continue
 		}
 
-		s, err := conn.GetDestination(context.Background(), test_project, resource.Primary.ID)
+		s, err := conn.GetDestination(context.Background(), testProject, resource.Primary.ID)
 		if err == nil {
 			if s.ID == resource.Primary.ID {
 				return fmt.Errorf("destination with ID (%v) still exists.", resource.Primary.ID)

--- a/lightstep/resource_servicenow_destination_test.go
+++ b/lightstep/resource_servicenow_destination_test.go
@@ -86,7 +86,7 @@ func TestAccServiceNowDestinationImport(t *testing.T) {
 			{
 				Config: `
 resource "lightstep_servicenow_destination" "servicenow" {
-	project_name = "terraform-provider-tests"
+    project_name = ` + fmt.Sprintf("\"%s\"", testProject) + `
 	destination_name = "do-not-delete-sn"
 	url = "https://example.com"
     auth {


### PR DESCRIPTION
PRs triggered by dependabot are not given access to the secrets configured for Github actions. This causes the acceptance tests to fail because there is no Lightstep api key. The reasoning for dependabot working this way is to prevent dependencies from exfiltrating those secrets or the other data that they have access to. (See https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-797125425) 

This means that we really should have a human look at the dependency updates before blindly running the acceptance tests. I think a reasonable solution to this is to disable the acceptance tests on dependabot PRs and add acceptance tests to the release workflow so that we know they always pass before releasing a new version.

This PR does the above.