### PR TITLE
LS-45128: Support custom data field for unified alerts

### DIFF
--- a/client/metric_conditions.go
+++ b/client/metric_conditions.go
@@ -18,6 +18,7 @@ type UnifiedConditionAttributes struct {
 	Description    string                      `json:"description"`
 	Labels         []Label                     `json:"labels"`
 	Type           string                      `json:"condition_type"`
+	CustomData     string                      `json:"custom-data"`
 	Expression     *Expression                 `json:"expression,omitempty"`
 	Queries        []MetricQueryWithAttributes `json:"metric-queries"`
 	AlertingRules  []AlertingRule              `json:"alerting-rules,omitempty"`

--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -58,6 +58,7 @@ EOT
 
 - `alerting_rule` (Block Set) (see [below for nested schema](#nestedblock--alerting_rule))
 - `composite_alert` (Block List, Max: 1) (see [below for nested schema](#nestedblock--composite_alert))
+- `custom_data` (String) Optional free-form string to include in alert notifications (max length 4096 bytes)
 - `description` (String)
 - `expression` (Block List, Max: 1) (see [below for nested schema](#nestedblock--expression))
 - `label` (Block Set) Labels can be key/value pairs or standalone values. (see [below for nested schema](#nestedblock--label))

--- a/docs/resources/metric_condition.md
+++ b/docs/resources/metric_condition.md
@@ -105,6 +105,7 @@ resource "lightstep_metric_condition" "beemo-requests" {
 ### Optional
 
 - `alerting_rule` (Block Set) (see [below for nested schema](#nestedblock--alerting_rule))
+- `custom_data` (String) Optional free-form string to include in alert notifications (max length 4096 bytes)
 - `description` (String)
 - `label` (Block Set) Labels can be key/value pairs or standalone values. (see [below for nested schema](#nestedblock--label))
 

--- a/lightstep/resource_metric_condition.go
+++ b/lightstep/resource_metric_condition.go
@@ -68,6 +68,11 @@ func resourceUnifiedCondition(conditionSchemaType ConditionSchemaType) *schema.R
 					},
 				},
 			},
+			"custom_data": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Optional free-form string to include in alert notifications (max length 4096 bytes)",
+			},
 			"alerting_rule": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -629,6 +634,7 @@ func getUnifiedConditionAttributesFromResource(d *schema.ResourceData, schemaTyp
 		Description:    d.Get("description").(string),
 		Expression:     expression,
 		Labels:         labels,
+		CustomData:     d.Get("custom_data").(string),
 		AlertingRules:  alertingRules,
 		Queries:        queries,
 		CompositeAlert: compositeAlert,
@@ -1216,6 +1222,10 @@ func setResourceDataFromUnifiedCondition(project string, c client.UnifiedConditi
 	labels := extractLabels(c.Attributes.Labels)
 	if err := d.Set("label", labels); err != nil {
 		return fmt.Errorf("unable to set labels resource field: %v", err)
+	}
+
+	if err := d.Set("custom_data", c.Attributes.CustomData); err != nil {
+		return fmt.Errorf("unable to set type resource field: %v", err)
 	}
 
 	if err := d.Set("type", "metric_alert"); err != nil {

--- a/lightstep/resource_metric_condition_test.go
+++ b/lightstep/resource_metric_condition_test.go
@@ -157,6 +157,8 @@ resource "lightstep_metric_condition" "test" {
 	  }
   }
 
+  custom_data = "this string could be json { example_key: \"example value\"} or anything you want"
+
   metric_query {
     metric         = "requests"
     query_name          = "a"
@@ -331,7 +333,8 @@ resource "lightstep_metric_condition" "test" {
 					testAccCheckMetricConditionExists(resourceName, &condition),
 					resource.TestCheckResourceAttr(resourceName, "name", "Too many requests"),
 					resource.TestCheckResourceAttr(resourceName, "description", "A link to a playbook"),
-					resource.TestCheckNoResourceAttr(resourceName, "labels"),
+					resource.TestCheckResourceAttr(resourceName, "label.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "custom_data", ""),
 					resource.TestCheckResourceAttr(resourceName, "metric_query.0.timeseries_operator_input_window_ms", "3600000"),
 					resource.TestCheckResourceAttr(resourceName, "metric_query.0.tql", ""),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "alerting_rule.*", map[string]string{
@@ -349,10 +352,12 @@ resource "lightstep_metric_condition" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetricConditionExists(resourceName, &condition),
 					resource.TestCheckResourceAttr(resourceName, "name", "updated"),
+					resource.TestCheckResourceAttr(resourceName, "label.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "label.0.key", "team"),
 					resource.TestCheckResourceAttr(resourceName, "label.0.value", "ontology"),
 					resource.TestCheckResourceAttr(resourceName, "description", "A link to a fresh playbook"),
 					resource.TestCheckResourceAttr(resourceName, "expression.0.is_no_data", "false"),
+					resource.TestCheckResourceAttr(resourceName, "custom_data", `this string could be json { example_key: "example value"} or anything you want`),
 				),
 			},
 			{
@@ -361,6 +366,7 @@ resource "lightstep_metric_condition" "test" {
 					testAccCheckMetricConditionExists(resourceName, &condition),
 					resource.TestCheckResourceAttr(resourceName, "name", "no data only"),
 					resource.TestCheckResourceAttr(resourceName, "expression.0.is_no_data", "true"),
+					resource.TestCheckResourceAttr(resourceName, "custom_data", ""),
 				),
 			},
 			{


### PR DESCRIPTION
What does this PR do?
----------------------
Adds support for the `custom-data` field in the LS terraform provider (we forgot to do this initially when adding it to the public API)

R: @lightstep/team-alerts-be 