### PR TITLE
Add a blurb for renaming of Lightstep to ServiceNow Cloud Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Lightstep Terraform Provider
 
+In August 2023, [Lightstep became ServiceNow
+Cloud Observability](https://docs.lightstep.com/docs/banner-faq). To ease the
+transition, all code artifacts will continue to use the Lightstep name. You
+don't need to do anything to keep using this provider.
+
 - Website: https://www.terraform.io
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)


### PR DESCRIPTION
Add a blurb for renaming of Lightstep to ServiceNow Cloud Observability