### PR TITLE
Fix issue updating a composite alert causes a panic in the provider

### DIFF
--- a/lightstep/resource_metric_condition.go
+++ b/lightstep/resource_metric_condition.go
@@ -445,7 +445,7 @@ func getCompositeSubAlertExpressionResource() *schema.Resource {
 							return true
 						}
 					}
-					return old == new
+					return false // do not suppress the diff otherwise!
 				},
 				MaxItems:    1,
 				MinItems:    0,


### PR DESCRIPTION
## Description
Suppressing the diff results in an empty "alert" element existing during the planning stage. This resulting in a panic, when applying, in `buildCompositeAlert()` line 1090 as "expressions" doesn't exist in the empty "alert" element.

This issue was introduced in v1.82.0 when the diff suppression function was added to the thresholds block.

## Steps to reproduce:

Using the attached example terraform, deploy the alert. Once deployed, modified one of the queries in the composite alert in alert.tf and plan the changes.

You should see something like the following, I've annotated (👈 ) the output below to highlight the problem
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # lightstep_alert.test_bug will be updated in-place
  ~ resource "lightstep_alert" "test_bug" {
        id           = "m9wZ5RZCN"
        name         = "TestCompositeAlertBug"
        # (2 unchanged attributes hidden)

      ~ composite_alert {
          - alert {
              - name = "A" -> null

              - expression {
                  - is_no_data = false -> null
                  - operand    = "above" -> null

                  - thresholds {
                      - warning = "95" -> null
                    }
                }

              - query {
                  - hidden         = false -> null
                  - hidden_queries = {} -> null
                  - query_name     = "a" -> null
                  - query_string   = <<-EOT
                        with
                        m2=metric tstv_capture_notifications_received_count|filter eventType=~"Complete|Partial"|rate 30m,30s|group_by [],sum;
                        m3=with
                        m0=metric tstv_capture_notifications_received_count|filter eventType=~"Complete|Partial|CaptureError"|rate 30m,30s|group_by [],sum;
                        m1=metric tstv_capture_notifications_received_count|filter eventType=="Failed"|rate 30m,30s|point value / 4|group_by [],sum;
                        join m0 + m1,m1=0;
                        join m2 / m3|point value * 100|reduce 30m,min
                    EOT -> null
                }
            }
          - alert {
              - name = "B" -> null

              - expression {
                  - is_no_data = false -> null
                  - operand    = "below" -> null

                  - thresholds {
                      - warning = "97.000001" -> null
                    }
                }

              - query {
                  - hidden         = false -> null
                  - hidden_queries = {} -> null
                  - query_name     = "b" -> null
                  - query_string   = <<-EOT
                        with
                        m2=metric tstv_capture_notifications_received_count|filter eventType=~"Complete|Partial"|rate 30m,30s|group_by [],sum;
                        m3=with
                        m0=metric tstv_capture_notifications_received_count|filter eventType=~"Complete|Partial|CaptureError"|rate 30m,30s|group_by [],sum;
                        m1=metric tstv_capture_notifications_received_count|filter eventType=="Failed"|rate 30m,30s|point value / 4|group_by [],sum;
                        join m0 + m1,m1=0;
                        join m2 / m3|point value * 100|reduce 30m,max
                    EOT -> null
                }
            }
          + alert {
              + name = "A"

              + expression {
                  + is_no_data = false
                  + operand    = "above"

                  + thresholds {
                      + warning = "95"
                    }
                }

              + query {
                  + hidden       = false
                  + query_name   = "a"
                  + query_string = <<-EOT
                        with
                        m2=metric tstv_capture_notifications_received_count|filter eventType=~"Complete|Partial"|rate 30m,30s|group_by [],sum;
                        m3=with
                        m0=metric tstv_capture_notifications_received_count|filter eventType=~"Complete|Partial|CaptureError"|rate 30m,30s|group_by [],sum;
                        m1=metric tstv_capture_notifications_received_count|filter eventType=="Failed"|rate 30m,30s|group_by [],sum;
                        join m0 + m1,m1=0;
                        join m2 / m3|point value * 100|reduce 30m,min
                    EOT
                }
            }
          + alert {
              + name = "B"

              + expression {
                  + is_no_data = false
                  + operand    = "below"

                  + thresholds {
                      + warning = "97.000001"
                    }
                }

              + query {
                  + hidden         = false
                  + hidden_queries = {}
                  + query_name     = "b"
                  + query_string   = <<-EOT
                        with
                        m2=metric tstv_capture_notifications_received_count|filter eventType=~"Complete|Partial"|rate 30m,30s|group_by [],sum;
                        m3=with
                        m0=metric tstv_capture_notifications_received_count|filter eventType=~"Complete|Partial|CaptureError"|rate 30m,30s|group_by [],sum;
                        m1=metric tstv_capture_notifications_received_count|filter eventType=="Failed"|rate 30m,30s|point value / 4|group_by [],sum;
                        join m0 + m1,m1=0;
                        join m2 / m3|point value * 100|reduce 30m,max
                    EOT
                }
            }
          + alert { 👈 Unexpected empty alert 
            }
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.

```

[example.zip](https://github.com/lightstep/terraform-provider-lightstep/files/12871502/example.zip)
