### PR TITLE
alerts: add description to alert.alerting_rule's id field

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -72,6 +72,10 @@ EOT
 <a id="nestedblock--alerting_rule"></a>
 ### Nested Schema for `alerting_rule`
 
+Required:
+
+- `id` (String) The id of the destination to receive notifications for this alert.
+
 Optional:
 
 - `include_filters` (List of Map of String) For alert queries that produce multiple group_by results, if at least one include_filters entry is specified, this destination only receives notifications for query results matching all of the specified group_by attributes.  
@@ -81,10 +85,6 @@ Required fields:
 - `update_interval` (String) An optional duration that represents the frequency at which to re-send an alert notification if an alert remains in a triggered state. 
 By default, notifications will only be sent when the alert status changes.  
 Values should be expressed as a duration (example: "2d").
-
-Read-Only:
-
-- `id` (String) The ID of this resource.
 
 
 <a id="nestedblock--composite_alert"></a>

--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -74,7 +74,7 @@ EOT
 
 Required:
 
-- `id` (String) The id of the destination to receive notifications for this alert.
+- `id` (String) The identifier of the destination to receive notifications for this alert.
 
 Optional:
 

--- a/docs/resources/metric_condition.md
+++ b/docs/resources/metric_condition.md
@@ -192,6 +192,10 @@ Optional:
 <a id="nestedblock--alerting_rule"></a>
 ### Nested Schema for `alerting_rule`
 
+Required:
+
+- `id` (String) The id of the destination to receive notifications for this alert.
+
 Optional:
 
 - `include_filters` (List of Map of String) For alert queries that produce multiple group_by results, if at least one include_filters entry is specified, this destination only receives notifications for query results matching all of the specified group_by attributes.  
@@ -201,10 +205,6 @@ Required fields:
 - `update_interval` (String) An optional duration that represents the frequency at which to re-send an alert notification if an alert remains in a triggered state. 
 By default, notifications will only be sent when the alert status changes.  
 Values should be expressed as a duration (example: "2d").
-
-Read-Only:
-
-- `id` (String) The ID of this resource.
 
 
 <a id="nestedblock--label"></a>

--- a/docs/resources/metric_condition.md
+++ b/docs/resources/metric_condition.md
@@ -194,7 +194,7 @@ Optional:
 
 Required:
 
-- `id` (String) The id of the destination to receive notifications for this alert.
+- `id` (String) The identifier of the destination to receive notifications for this alert.
 
 Optional:
 

--- a/lightstep/resource_metric_condition.go
+++ b/lightstep/resource_metric_condition.go
@@ -147,8 +147,9 @@ By default, notifications will only be sent when the alert status changes.
 Values should be expressed as a duration (example: "2d").`,
 		},
 		"id": {
-			Type:     schema.TypeString,
-			Required: true,
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: `The id of the destination to receive notifications for this alert.`,
 		},
 		"include_filters": {
 			Type:     schema.TypeList,

--- a/lightstep/resource_metric_condition.go
+++ b/lightstep/resource_metric_condition.go
@@ -149,7 +149,7 @@ Values should be expressed as a duration (example: "2d").`,
 		"id": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: `The id of the destination to receive notifications for this alert.`,
+			Description: `The identifier of the destination to receive notifications for this alert.`,
 		},
 		"include_filters": {
 			Type:     schema.TypeList,


### PR DESCRIPTION
There was no description for the id field for an alerting_rule embedded in a unified alert. This was causing the docs generator to assume it is a Read-Only field representing an alerting_rule's unique identifier, which is incorrect.