### PR TITLE
alerts: add optional triggered for durations

### DIFF
--- a/client/metric_conditions.go
+++ b/client/metric_conditions.go
@@ -48,14 +48,17 @@ type Expression struct {
 }
 
 type SubAlertExpression struct {
-	Thresholds Thresholds `json:"thresholds"`
-	Operand    string     `json:"operand"`
-	IsNoData   bool       `json:"enable-no-data-alert,omitempty"`
+	Thresholds       Thresholds `json:"thresholds"`
+	Operand          string     `json:"operand"`
+	IsNoData         bool       `json:"enable-no-data-alert,omitempty"`
+	NoDataDurationMs *uint64    `json:"no-data-duration-ms,omitempty"`
 }
 
 type Thresholds struct {
-	Warning  *float64 `json:"warning,omitempty"`
-	Critical *float64 `json:"critical,omitempty"`
+	Warning            *float64 `json:"warning,omitempty"`
+	WarningDurationMs  *uint64  `json:"warning-duration-ms,omitempty"`
+	Critical           *float64 `json:"critical,omitempty"`
+	CriticalDurationMs *uint64  `json:"critical-duration-ms,omitempty"`
 }
 
 type DependencyMapOptions struct {

--- a/client/metric_conditions.go
+++ b/client/metric_conditions.go
@@ -51,14 +51,14 @@ type SubAlertExpression struct {
 	Thresholds       Thresholds `json:"thresholds"`
 	Operand          string     `json:"operand"`
 	IsNoData         bool       `json:"enable-no-data-alert,omitempty"`
-	NoDataDurationMs *uint64    `json:"no-data-duration-ms,omitempty"`
+	NoDataDurationMs *int       `json:"no-data-duration-ms,omitempty"`
 }
 
 type Thresholds struct {
 	Warning            *float64 `json:"warning,omitempty"`
-	WarningDurationMs  *uint64  `json:"warning-duration-ms,omitempty"`
+	WarningDurationMs  *int     `json:"warning-duration-ms,omitempty"`
 	Critical           *float64 `json:"critical,omitempty"`
-	CriticalDurationMs *uint64  `json:"critical-duration-ms,omitempty"`
+	CriticalDurationMs *int     `json:"critical-duration-ms,omitempty"`
 }
 
 type DependencyMapOptions struct {

--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -110,6 +110,7 @@ Optional:
 Optional:
 
 - `is_no_data` (Boolean) If true, a notification is sent when the alert query returns no data. If false, notifications aren't sent in this scenario.
+- `no_data_duration_ms` (Number) No data must be seen for this duration before the status changes.
 - `operand` (String) Required when at least one threshold (Critical, Warning) is defined. Indicates whether the alert triggers when the value is above the threshold or below the threshold.
 - `thresholds` (Block List, Max: 1) Optional values defining the thresholds at which this alert transitions into Critical or Warning states. If a particular threshold is not specified, the alert never transitions into that state. (see [below for nested schema](#nestedblock--composite_alert--alert--expression--thresholds))
 
@@ -119,7 +120,9 @@ Optional:
 Optional:
 
 - `critical` (String) Defines the threshold for the alert to transition to a Critical (more severe) status.
+- `critical_duration_ms` (Number) Critical threshold must be breached for this duration before the status changes.
 - `warning` (String) Defines the threshold for the alert to transition to a Warning (less severe) status.
+- `warning_duration_ms` (Number) Critical threshold must be breached for this duration before the status changes.
 
 
 
@@ -161,6 +164,7 @@ Optional:
 
 - `is_multi` (Boolean) When false, send a single notification whenever any number of group_by values exceeds the alert threshold. When true, send individual notifications for each distinct group_by value that exceeds the threshold.
 - `is_no_data` (Boolean) If true, a notification is sent when the alert query returns no data. If false, notifications aren't sent in this scenario.
+- `no_data_duration_ms` (Number) No data must be seen for this duration before the status changes.
 - `operand` (String) Required when at least one threshold (Critical, Warning) is defined. Indicates whether the alert triggers when the value is above the threshold or below the threshold.
 - `thresholds` (Block List, Max: 1) Optional values defining the thresholds at which this alert transitions into Critical or Warning states. If a particular threshold is not specified, the alert never transitions into that state. (see [below for nested schema](#nestedblock--expression--thresholds))
 
@@ -170,7 +174,9 @@ Optional:
 Optional:
 
 - `critical` (String) Defines the threshold for the alert to transition to a Critical (more severe) status.
+- `critical_duration_ms` (Number) Critical threshold must be breached for this duration before the status changes.
 - `warning` (String) Defines the threshold for the alert to transition to a Warning (less severe) status.
+- `warning_duration_ms` (Number) Critical threshold must be breached for this duration before the status changes.
 
 
 

--- a/docs/resources/metric_condition.md
+++ b/docs/resources/metric_condition.md
@@ -120,6 +120,7 @@ Optional:
 
 - `is_multi` (Boolean) When false, send a single notification whenever any number of group_by values exceeds the alert threshold. When true, send individual notifications for each distinct group_by value that exceeds the threshold.
 - `is_no_data` (Boolean) If true, a notification is sent when the alert query returns no data. If false, notifications aren't sent in this scenario.
+- `no_data_duration_ms` (Number) No data must be seen for this duration before the status changes.
 - `operand` (String) Required when at least one threshold (Critical, Warning) is defined. Indicates whether the alert triggers when the value is above the threshold or below the threshold.
 - `thresholds` (Block List, Max: 1) Optional values defining the thresholds at which this alert transitions into Critical or Warning states. If a particular threshold is not specified, the alert never transitions into that state. (see [below for nested schema](#nestedblock--expression--thresholds))
 
@@ -129,7 +130,9 @@ Optional:
 Optional:
 
 - `critical` (String) Defines the threshold for the alert to transition to a Critical (more severe) status.
+- `critical_duration_ms` (Number) Critical threshold must be breached for this duration before the status changes.
 - `warning` (String) Defines the threshold for the alert to transition to a Warning (less severe) status.
+- `warning_duration_ms` (Number) Critical threshold must be breached for this duration before the status changes.
 
 
 

--- a/lightstep/resource_alert.go
+++ b/lightstep/resource_alert.go
@@ -68,7 +68,7 @@ func getCompositeAlertFromUnifiedConditionResourceData(compositeAlertIn *client.
 		if subAlertIn.Expression.NoDataDurationMs != nil {
 			subAlertExpressionMap["no_data_duration_ms"] = subAlertIn.Expression.NoDataDurationMs
 		}
-		subAlerts = append(subAlerts, map[string]interface{}{})
+		subAlerts = append(subAlerts, subAlertExpressionMap)
 	}
 
 	return []map[string][]map[string]interface{}{{

--- a/lightstep/resource_alert.go
+++ b/lightstep/resource_alert.go
@@ -2,6 +2,7 @@ package lightstep
 
 import (
 	"fmt"
+
 	"github.com/lightstep/terraform-provider-lightstep/client"
 )
 
@@ -52,7 +53,7 @@ func getCompositeAlertFromUnifiedConditionResourceData(compositeAlertIn *client.
 			return nil, err
 		}
 
-		subAlerts = append(subAlerts, map[string]interface{}{
+		subAlertExpressionMap := map[string]interface{}{
 			"name":  subAlertIn.Name,
 			"title": subAlertIn.Title,
 			"expression": []map[string]interface{}{
@@ -63,7 +64,11 @@ func getCompositeAlertFromUnifiedConditionResourceData(compositeAlertIn *client.
 				},
 			},
 			"query": queries,
-		})
+		}
+		if subAlertIn.Expression.NoDataDurationMs != nil {
+			subAlertExpressionMap["no_data_duration_ms"] = subAlertIn.Expression.NoDataDurationMs
+		}
+		subAlerts = append(subAlerts, map[string]interface{}{})
 	}
 
 	return []map[string][]map[string]interface{}{{

--- a/lightstep/resource_alert_test.go
+++ b/lightstep/resource_alert_test.go
@@ -62,13 +62,6 @@ resource "lightstep_alert" "test" {
   alerting_rule {
     id          = lightstep_slack_destination.slack.id
     update_interval = "1h"
-
-    include_filters = [
-      {
-        key   = "project_name"
-        value = "catlab"
-      }
-    ]
   }
 }
 `
@@ -103,13 +96,6 @@ resource "lightstep_alert" "test" {
   alerting_rule {
     id          = lightstep_slack_destination.slack.id
     update_interval = "1h"
-
-    include_filters = [
-      {
-        key   = "project_name"
-        value = "catlab"
-      }
-    ]
   }
 }
 `
@@ -206,13 +192,6 @@ EOT
   alerting_rule {
     id          = lightstep_slack_destination.slack.id
     update_interval = "1h"
-
-    include_filters = [
-      {
-        key   = "project_name"
-        value = "catlab"
-      }
-    ]
   }
 }
 `, uqlQuery)
@@ -251,13 +230,6 @@ EOT
   alerting_rule {
     id          = lightstep_slack_destination.slack.id
     update_interval = "1h"
-
-    include_filters = [
-      {
-        key   = "project_name"
-        value = "catlab"
-      }
-    ]
   }
 }
 `, uqlQuery)
@@ -553,11 +525,6 @@ EOT
   alerting_rule {
     id          = lightstep_slack_destination.slack.id
     update_interval = "1h"
-
-    include_filters = [{
-      key   = "project_name"
-      value = "catlab"
-    }]
   }
 }
 `, uqlQuery)
@@ -706,13 +673,6 @@ resource "lightstep_alert" "errors" {
 	alerting_rule {
 	  id          = lightstep_slack_destination.slack.id
 	  update_interval = "1h"
-	
-	  include_filters = [
-	    {
-	      key   = "project_name"
-	      value = "catlab"
-	    }
-	  ]
 	}
 	}
 	`
@@ -769,13 +729,6 @@ resource "lightstep_alert" "test" {
  alerting_rule {
    id          = lightstep_slack_destination.slack.id
    update_interval = "1h"
-
-   include_filters = [
-     {
-       key   = "project_name"
-       value = "catlab"
-     }
-   ]
  }
 }
 `

--- a/lightstep/resource_alert_test.go
+++ b/lightstep/resource_alert_test.go
@@ -1137,9 +1137,9 @@ resource "lightstep_alert" "test" {
       operand  = "above"
 	  thresholds {
 		critical  = 10
-        critical_duration_ms = 120000
+        critical_duration_ms = 180000
 		warning = 5
-        warning_duration_ms = 180000
+        warning_duration_ms = 120000
 	  }
   }
 
@@ -1147,7 +1147,7 @@ resource "lightstep_alert" "test" {
 	query_name                          = "a"
 	hidden                              = false
     display                             = "line"
-	query_string                        = "metric requests | rate 1h | filter "service_name" == "frontend" | group_by ["method"], mean"
+	query_string                        = "metric requests | rate 1h | filter service_name == frontend | group_by [method], mean"
   }
 }
 `

--- a/lightstep/resource_alert_test.go
+++ b/lightstep/resource_alert_test.go
@@ -1172,3 +1172,53 @@ resource "lightstep_alert" "composite_diff_test" {
 		},
 	})
 }
+
+func TestAccAlertWithThresholdDurations(t *testing.T) {
+	var condition client.UnifiedCondition
+
+	conditionConfig := `
+resource "lightstep_alert" "test" {
+  project_name = "` + testProject + `"
+  name = "Too many requests"
+
+  expression {
+	  is_multi   = true
+	  is_no_data = true
+      no_data_duration_ms = 60000
+      operand  = "above"
+	  thresholds {
+		critical  = 10
+        critical_duration_ms = 120000
+		warning = 5
+        warning_duration_ms = 180000
+	  }
+  }
+
+  query {
+	query_name                          = "a"
+	hidden                              = false
+    display                             = "line"
+	query_string                        = "metric requests | rate 1h | filter "service_name" == "frontend" | group_by ["method"], mean"
+  }
+}
+`
+
+	resourceName := "lightstep_alert.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccMetricConditionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: conditionConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLightstepAlertExists(resourceName, &condition),
+					resource.TestCheckResourceAttr(resourceName, "name", "Too many requests"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.no_data_duration_ms", "60000"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.thresholds.0.warning_duration_ms", "120000"),
+					resource.TestCheckResourceAttr(resourceName, "expression.0.thresholds.0.critical_duration_ms", "180000"),
+				),
+			},
+		},
+	})
+}

--- a/lightstep/resource_alert_test.go
+++ b/lightstep/resource_alert_test.go
@@ -254,10 +254,6 @@ EOT
 					resource.TestCheckResourceAttr(resourceName, "name", "Too many requests"),
 					resource.TestCheckResourceAttr(resourceName, "description", "A link to a playbook"),
 					resource.TestCheckResourceAttr(resourceName, "query.0.query_string", uqlQuery+"\n"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "alerting_rule.*", map[string]string{
-						"include_filters.0.key":   "project_name",
-						"include_filters.0.value": "catlab",
-					}),
 					resource.TestCheckResourceAttr(resourceName, "expression.0.is_no_data", "true"),
 				),
 			},

--- a/lightstep/resource_metric_condition.go
+++ b/lightstep/resource_metric_condition.go
@@ -703,9 +703,9 @@ func buildSubAlertExpression(singleExpression map[string]interface{}) (*client.S
 	}
 
 	noDataDuration := singleExpression["no_data_duration_ms"]
-	if noDataDuration != "" {
-		d, err := strconv.ParseUint(noDataDuration.(string), 64, strconv.IntSize)
-		if err != nil {
+	if noDataDuration != nil && noDataDuration != "" && noDataDuration != 0 {
+		d, ok := noDataDuration.(int)
+		if !ok {
 			return e, err
 		}
 		e.NoDataDurationMs = &d
@@ -1042,20 +1042,20 @@ func buildThresholds(singleExpression map[string]interface{}) (client.Thresholds
 		t.Warning = &w
 	}
 
-	criticalDuration := singleExpression["critical_duration_ms"]
-	if criticalDuration != "" {
-		d, err := strconv.ParseUint(criticalDuration.(string), 64, strconv.IntSize)
-		if err != nil {
-			return t, err
+	criticalDuration := thresholdsObj["critical_duration_ms"]
+	if criticalDuration != nil && criticalDuration != "" && criticalDuration != 0 {
+		d, ok := criticalDuration.(int)
+		if !ok {
+			return t, fmt.Errorf("unexpected format for critical_duration_ms")
 		}
 		t.CriticalDurationMs = &d
 	}
 
-	warningDuration := singleExpression["warning_duration_ms"]
-	if criticalDuration != "" {
-		d, err := strconv.ParseUint(warningDuration.(string), 64, strconv.IntSize)
-		if err != nil {
-			return t, err
+	warningDuration := thresholdsObj["warning_duration_ms"]
+	if warningDuration != nil && warningDuration != "" && criticalDuration != 0 {
+		d, ok := warningDuration.(int)
+		if !ok {
+			return t, fmt.Errorf("unexpected format for warning_duration_ms")
 		}
 		t.WarningDurationMs = &d
 	}
@@ -1286,7 +1286,8 @@ func setResourceDataFromUnifiedCondition(project string, c client.UnifiedConditi
 		if c.Attributes.Expression.NoDataDurationMs != nil {
 			expressionMap["no_data_duration_ms"] = c.Attributes.Expression.NoDataDurationMs
 		}
-		if err := d.Set("expression", expressionMap); err != nil {
+		expressionSlice := []map[string]interface{}{expressionMap}
+		if err := d.Set("expression", expressionSlice); err != nil {
 			return fmt.Errorf("unable to set expression resource field: %v", err)
 		}
 	}

--- a/lightstep/resource_metric_condition.go
+++ b/lightstep/resource_metric_condition.go
@@ -341,7 +341,6 @@ func getThresholdSchemaMap() map[string]*schema.Schema {
 		"critical_duration_ms": {
 			Type:        schema.TypeInt,
 			Optional:    true,
-			Default:     false,
 			Description: "Critical threshold must be breached for this duration before the status changes.",
 		},
 		"warning": {
@@ -352,7 +351,6 @@ func getThresholdSchemaMap() map[string]*schema.Schema {
 		"warning_duration_ms": {
 			Type:        schema.TypeInt,
 			Optional:    true,
-			Default:     false,
 			Description: "Critical threshold must be breached for this duration before the status changes.",
 		},
 	}
@@ -437,7 +435,6 @@ func getCompositeSubAlertExpressionResource() *schema.Resource {
 			"no_data_duration_ms": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     false,
 				Description: "No data must be seen for this duration before the status changes.",
 			},
 			"operand": {

--- a/lightstep/resource_metric_condition.go
+++ b/lightstep/resource_metric_condition.go
@@ -542,7 +542,8 @@ func (p *resourceUnifiedConditionImp) resourceUnifiedConditionRead(ctx context.C
 		return diag.FromErr(fmt.Errorf("failed to translate resource attributes: %v", err))
 	}
 
-	cond, err := c.GetUnifiedCondition(ctx, d.Get("project_name").(string), d.Id())
+	projectName := d.Get("project_name").(string)
+	cond, err := c.GetUnifiedCondition(ctx, projectName, d.Id())
 	if err != nil {
 		apiErr, ok := err.(client.APIResponseCarrier)
 		if !ok {
@@ -557,7 +558,6 @@ func (p *resourceUnifiedConditionImp) resourceUnifiedConditionRead(ctx context.C
 		return diag.FromErr(fmt.Errorf("failed to get metric condition: %v", apiErr))
 	}
 
-	projectName := d.Get("project_name").(string)
 	legacy, err := metricConditionHasEquivalentLegacyQueries(ctx, c, projectName, prevAttrs, &cond.Attributes)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to compare legacy queries: %v", err))
@@ -566,7 +566,8 @@ func (p *resourceUnifiedConditionImp) resourceUnifiedConditionRead(ctx context.C
 		cond.Attributes.Queries = prevAttrs.Queries
 	}
 
-	if err := setResourceDataFromUnifiedCondition(d.Get("project_name").(string), *cond, d, p.conditionSchemaType); err != nil {
+	err = setResourceDataFromUnifiedCondition(projectName, *cond, d, p.conditionSchemaType)
+	if err != nil {
 		return diag.FromErr(fmt.Errorf("failed to set metric condition from API response to terraform state: %v", err))
 	}
 


### PR DESCRIPTION
Add support for optional triggered for durations: warning duration, critical duration and no data duration.

I didn't look into preventing it from being added to the metric condition resource, I assume it would be fairly messy because they share so much code.