### PR TITLE
Add support for Trace List visualization

### DIFF
--- a/lightstep/resource_dashboard.go
+++ b/lightstep/resource_dashboard.go
@@ -29,6 +29,7 @@ func getUnifiedQuerySchemaMap() map[string]*schema.Schema {
 				"scatter_plot",
 				"ordered_list",
 				"table",
+				"traces_list",
 			}, false),
 		},
 		// See https://github.com/hashicorp/terraform-plugin-sdk/issues/155


### PR DESCRIPTION
Terraform should accept `traces_list` as a valid `display_type` for a query.