### PR TITLE
client: support EU environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ The `exporter` utility is built-in to the provider binary and requires certain e
 For the LIGHTSTEP_ENV variable:
 
 - public = app.lightstep.com
+- eu-public = app.eu.lightstep.com
 - meta = app-meta.lightstep.com
 - staging = app-staging.lightstep.com
+- eu-staging = app.eu-staging.lightstep.com
 
 ```
 $ export LIGHTSTEP_API_KEY=....

--- a/client/client.go
+++ b/client/client.go
@@ -78,7 +78,7 @@ func NewClient(apiKey string, orgName string, env string) *Client {
 	return NewClientWithUserAgent(apiKey, orgName, env, fmt.Sprintf("%s/%s", DefaultUserAgent, version.ProviderVersion))
 }
 
-func NewClientWithUserAgent(apiKey string, orgName string, env string, userAgent string) *Client {
+func resolveBaseURL(env string) string {
 	// Let the user override the API base URL.
 	// e.g. http://localhost:8080
 	envBaseURL := os.Getenv("LIGHTSTEP_API_BASE_URL")
@@ -89,9 +89,19 @@ func NewClientWithUserAgent(apiKey string, orgName string, env string, userAgent
 		baseURL = envBaseURL
 	} else if env == "public" {
 		baseURL = "https://api.lightstep.com"
+	} else if env == "eu-public" {
+		baseURL = "https://api.eu.lightstep.com"
+	} else if env == "eu-staging" {
+		baseURL = "https://api.eu-staging.lightstep.com"
 	} else {
 		baseURL = fmt.Sprintf("https://api-%v.lightstep.com", env)
 	}
+
+	return baseURL
+}
+
+func NewClientWithUserAgent(apiKey string, orgName string, env string, userAgent string) *Client {
+	baseURL := resolveBaseURL(env)
 
 	fullBaseURL := fmt.Sprintf("%s/public/v0.2/%v", baseURL, orgName)
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,8 +1,9 @@
 package client
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNew_public(t *testing.T) {
@@ -23,4 +24,13 @@ func TestNew_env_var_provided_baseURL(t *testing.T) {
 	t.Setenv("LIGHTSTEP_API_BASE_URL", "http://localhost:8080")
 	c := NewClient("api-key", "org-name", "public")
 	assert.Equal(t, "http://localhost:8080/public/v0.2/org-name", c.baseURL)
+}
+
+func Test_resolveBaseURL(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "https://api.lightstep.com", resolveBaseURL("public"))
+	assert.Equal(t, "https://api-meta.lightstep.com", resolveBaseURL("meta"))
+	assert.Equal(t, "https://api.eu.lightstep.com", resolveBaseURL("eu-public"))
+	assert.Equal(t, "https://api.eu-staging.lightstep.com", resolveBaseURL("eu-staging"))
+	assert.Equal(t, "https://api-other.lightstep.com", resolveBaseURL("other"))
 }

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -170,8 +170,9 @@ func Run(args ...string) error {
 
 	// default to public API environment
 	lightstepEnv := "public"
-	if len(os.Getenv("LIGHTSTEP_ENV")) > 0 {
-		lightstepEnv = os.Getenv("LIGHTSTEP_ENV")
+	userEnv := os.Getenv("LIGHTSTEP_ENV")
+	if len(userEnv) > 0 {
+		lightstepEnv = userEnv
 	}
 
 	if len(args) < 4 {


### PR DESCRIPTION
Add new env strings for `LIGHTSTEP_ENV` to support the EU instances `eu-public` and `eu-staging`. Add a unit test for the two new envs.