### PR TITLE
Fix bug where warning threshold duration could not be applied

### DIFF
--- a/lightstep/resource_metric_condition.go
+++ b/lightstep/resource_metric_condition.go
@@ -1050,7 +1050,7 @@ func buildThresholds(singleExpression map[string]interface{}) (client.Thresholds
 	}
 
 	warningDuration := thresholdsObj["warning_duration_ms"]
-	if warningDuration != nil && warningDuration != "" && criticalDuration != 0 {
+	if warningDuration != nil && warningDuration != "" && warningDuration != 0 {
 		d, ok := warningDuration.(int)
 		if !ok {
 			return t, fmt.Errorf("unexpected format for warning_duration_ms")


### PR DESCRIPTION
One of the checks for the warning threshold was checking the critical threshold duration rather than the warning threshold duration. This made it impossible to specify just one of the durations as setting just error duration would cause a nil pointer dereference and setting just warning duration would be ignored.